### PR TITLE
Update flutter_keyboard_visibility dependency

### DIFF
--- a/packages/flutter_form_bloc/pubspec.yaml
+++ b/packages/flutter_form_bloc/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   # form_bloc:
   #   path: ../form_bloc
   rxdart: ^0.24.0
-  flutter_keyboard_visibility: ^2.0.0
+  flutter_keyboard_visibility: ">=2.0.0 <=3.1.0"
   collection: ^1.14.11
   intl: ">=0.15.1 <0.17.0"
 


### PR DESCRIPTION
flutter_keyboard_visibility version 3.x use Android Plugin v2. Essential when Flutter is integrated into an existing app as a module.