### PR TITLE
[bug] fixing type error with updated suggestion function

### DIFF
--- a/packages/form_bloc/lib/src/blocs/field/field_bloc.dart
+++ b/packages/form_bloc/lib/src/blocs/field/field_bloc.dart
@@ -68,7 +68,7 @@ abstract class FieldBloc {
 abstract class SingleFieldBloc<
     Value,
     Suggestion,
-    State extends FieldBlocState<Value, Suggestion?, ExtraData?>,
+    State extends FieldBlocState<Value, Suggestion, ExtraData?>,
     ExtraData> extends Bloc<FieldBlocEvent, State> with FieldBloc {
   final Value _initialValue;
 

--- a/packages/form_bloc/lib/src/blocs/input_field/input_field_bloc.dart
+++ b/packages/form_bloc/lib/src/blocs/input_field/input_field_bloc.dart
@@ -2,7 +2,7 @@ part of '../field/field_bloc.dart';
 
 /// A `FieldBloc` used for any type, for example `DateTime` or `File`.
 class InputFieldBloc<Value, ExtraData> extends SingleFieldBloc<Value?, Value,
-    InputFieldBlocState<Value?, ExtraData?>, ExtraData?> {
+    InputFieldBlocState<Value, ExtraData?>, ExtraData?> {
   /// ## InputFieldBloc<Value, ExtraData>
   ///
   /// ### Properties:


### PR DESCRIPTION
Fixing type error will be throw when updateSuggestions is called
e.g
``` dart
text1.updateSuggestions((pattern) async => ['sample']);
```