### PR TITLE
Fixed an issue where the bloc builder did not disappear from the ui…

### DIFF
--- a/form_bloc_web/lib/examples/list_fields_form.dart
+++ b/form_bloc_web/lib/examples/list_fields_form.dart
@@ -21,7 +21,7 @@ class App extends StatelessWidget {
 class ListFieldFormBloc extends FormBloc<String, String> {
   final clubName = TextFieldBloc(name: 'clubName');
 
-  final members = ListFieldBloc<MemberFieldBloc>(name: 'members');
+  final members = ListFieldBloc<MemberFieldBloc, dynamic>(name: 'members');
 
   ListFieldFormBloc() {
     addFieldBlocs(
@@ -91,14 +91,14 @@ class ListFieldFormBloc extends FormBloc<String, String> {
 class MemberFieldBloc extends GroupFieldBloc {
   final TextFieldBloc firstName;
   final TextFieldBloc lastName;
-  final ListFieldBloc<TextFieldBloc> hobbies;
+  final ListFieldBloc<TextFieldBloc, dynamic> hobbies;
 
   MemberFieldBloc({
     required this.firstName,
     required this.lastName,
     required this.hobbies,
     String? name,
-  }) : super([firstName, lastName, hobbies], name: name);
+  }) : super(name: name, fieldBlocs: [firstName, lastName, hobbies]);
 }
 
 class Club {
@@ -216,8 +216,8 @@ class ListFieldsForm extends StatelessWidget {
                           prefixIcon: Icon(Icons.sentiment_satisfied),
                         ),
                       ),
-                      BlocBuilder<ListFieldBloc<MemberFieldBloc>,
-                          ListFieldBlocState<MemberFieldBloc>>(
+                      BlocBuilder<ListFieldBloc<MemberFieldBloc, dynamic>,
+                          ListFieldBlocState<MemberFieldBloc, dynamic>>(
                         bloc: formBloc.members,
                         builder: (context, state) {
                           if (state.fieldBlocs.isNotEmpty) {
@@ -309,8 +309,8 @@ class MemberCard extends StatelessWidget {
                 labelText: 'Last Name',
               ),
             ),
-            BlocBuilder<ListFieldBloc<TextFieldBloc>,
-                ListFieldBlocState<TextFieldBloc>>(
+            BlocBuilder<ListFieldBloc<TextFieldBloc, dynamic>,
+                ListFieldBlocState<TextFieldBloc, dynamic>>(
               bloc: memberField.hobbies,
               builder: (context, state) {
                 if (state.fieldBlocs.isNotEmpty) {

--- a/packages/flutter_form_bloc/pubspec.yaml
+++ b/packages/flutter_form_bloc/pubspec.yaml
@@ -13,9 +13,9 @@ dependencies:
     sdk: flutter
 #  bloc: ^7.0.0
   flutter_bloc: ^7.0.1
-#  form_bloc:
-#    path: '../form_bloc'
-  form_bloc: ^0.20.6
+  form_bloc:
+    path: '../form_bloc'
+#  form_bloc: ^0.20.6
   rxdart: ^0.27.1
   flutter_keyboard_visibility: ^5.0.2
   collection: ^1.15.0

--- a/packages/form_bloc/lib/src/blocs/boolean_field/boolean_field_state.dart
+++ b/packages/form_bloc/lib/src/blocs/boolean_field/boolean_field_state.dart
@@ -35,7 +35,7 @@ class BooleanFieldBlocState<ExtraData>
       Optional<Suggestions<bool>>? suggestions,
       bool? isValidated,
       bool? isValidating,
-      FormBloc? formBloc,
+      Optional<FormBloc?>? formBloc,
       Optional<ExtraData?>? extraData}) {
     return BooleanFieldBlocState(
       value: value == null ? this.value : value.orNull,
@@ -44,7 +44,7 @@ class BooleanFieldBlocState<ExtraData>
       suggestions: suggestions == null ? this.suggestions : suggestions.orNull,
       isValidated: isValidated ?? this.isValidated,
       isValidating: isValidating ?? this.isValidating,
-      formBloc: formBloc ?? this.formBloc,
+      formBloc: formBloc == null ? this.formBloc : formBloc.orNull,
       name: name,
       toJson: _toJson,
       extraData: extraData == null ? this.extraData : extraData.orNull,

--- a/packages/form_bloc/lib/src/blocs/field/field_bloc.dart
+++ b/packages/form_bloc/lib/src/blocs/field/field_bloc.dart
@@ -274,6 +274,8 @@ abstract class SingleFieldBloc<
       yield* _onUpdateFieldBlocExtraData(event);
     } else if (event is AddFormBlocAndAutoValidateToFieldBloc) {
       yield* _onAddFormBlocAndAutoValidateToFieldBloc(event);
+    } else if (event is RemoveFormBlocToFieldBloc) {
+      yield* _onRemoveFormBlocToFieldBloc(event);
     } else {
       yield* _mapCustomEventToState(event);
     }
@@ -535,10 +537,21 @@ abstract class SingleFieldBloc<
         error: Optional.absent(),
         isValidated: false,
         isValidating: false,
-        formBloc: event.formBloc,
+        formBloc: Optional.fromNullable(event.formBloc),
       ) as State;
     } else {
-      yield state.copyWith(formBloc: event.formBloc) as State;
+      yield state.copyWith(
+        formBloc: Optional.fromNullable(event.formBloc),
+      ) as State;
+    }
+  }
+
+  Stream<State> _onRemoveFormBlocToFieldBloc(
+      RemoveFormBlocToFieldBloc event) async* {
+    if (state.formBloc == event.formBloc) {
+      yield state.copyWith(
+        formBloc: Optional.absent(),
+      ) as State;
     }
   }
 

--- a/packages/form_bloc/lib/src/blocs/field/field_event.dart
+++ b/packages/form_bloc/lib/src/blocs/field/field_event.dart
@@ -258,3 +258,12 @@ class AddFormBlocAndAutoValidateToFieldBloc extends FieldBlocEvent {
   @override
   List<Object?> get props => [formBloc, autoValidate];
 }
+
+class RemoveFormBlocToFieldBloc extends FieldBlocEvent {
+  final FormBloc<dynamic, dynamic> formBloc;
+
+  RemoveFormBlocToFieldBloc({required this.formBloc});
+
+  @override
+  List<Object?> get props => [formBloc];
+}

--- a/packages/form_bloc/lib/src/blocs/field/field_state.dart
+++ b/packages/form_bloc/lib/src/blocs/field/field_state.dart
@@ -96,7 +96,7 @@ abstract class FieldBlocState<Value, Suggestion, ExtraData> extends Equatable {
     Optional<Suggestions<Suggestion>>? suggestions,
     bool? isValidated,
     bool? isValidating,
-    FormBloc? formBloc,
+    Optional<FormBloc?> formBloc,
     Optional<ExtraData>? extraData,
   });
 

--- a/packages/form_bloc/lib/src/blocs/form/form_bloc.dart
+++ b/packages/form_bloc/lib/src/blocs/form/form_bloc.dart
@@ -803,6 +803,11 @@ abstract class FormBloc<SuccessResponse, FailureResponse> extends Bloc<
         Stream.value(state),
         stream,
       ]).firstWhere((state) => state == newState);
+
+      FormBlocUtils.removeFormBlocToFieldBlocs(
+        fieldBlocs: fieldBlocs,
+        formBloc: this,
+      );
     }
   }
 

--- a/packages/form_bloc/lib/src/blocs/form/form_bloc_utils.dart
+++ b/packages/form_bloc/lib/src/blocs/form/form_bloc_utils.dart
@@ -376,4 +376,56 @@ class FormBlocUtils {
       return null;
     }
   }
+
+  static void addFormBlocAndAutoValidateToFieldBlocs({
+    required List<FieldBloc> fieldBlocs,
+    required FormBloc? formBloc,
+    bool autoValidate = false,
+  }) {
+    final allFieldBlocs = FormBlocUtils.getAllFieldBlocs(fieldBlocs);
+
+    allFieldBlocs.forEach((e) {
+      if (e is SingleFieldBloc) {
+        e.add(AddFormBlocAndAutoValidateToFieldBloc(
+          formBloc: formBloc,
+          autoValidate: autoValidate,
+        ));
+      } else if (e is ListFieldBloc) {
+        e.add(AddFormBlocAndAutoValidateToListFieldBloc(
+          formBloc: formBloc,
+          autoValidate: autoValidate,
+        ));
+      } else if (e is GroupFieldBloc) {
+        e.add(AddFormBlocAndAutoValidateToGroupFieldBloc(
+          formBloc: formBloc,
+          autoValidate: autoValidate,
+        ));
+      }
+    });
+  }
+
+  static void removeFormBlocToFieldBlocs({
+    required List<FieldBloc> fieldBlocs,
+    required FormBloc? formBloc,
+  }) {
+    if (formBloc == null) return;
+
+    final allFieldBlocs = FormBlocUtils.getAllFieldBlocs(fieldBlocs);
+
+    allFieldBlocs.forEach((e) {
+      if (e is SingleFieldBloc) {
+        e.add(RemoveFormBlocToFieldBloc(
+          formBloc: formBloc,
+        ));
+      } else if (e is ListFieldBloc) {
+        e.add(RemoveFormBlocToListFieldBloc(
+          formBloc: formBloc,
+        ));
+      } else if (e is GroupFieldBloc) {
+        e.add(RemoveFormBlocToGroupFieldBloc(
+          formBloc: formBloc,
+        ));
+      }
+    });
+  }
 }

--- a/packages/form_bloc/lib/src/blocs/group_field/group_field_bloc.dart
+++ b/packages/form_bloc/lib/src/blocs/group_field/group_field_bloc.dart
@@ -12,6 +12,15 @@ class AddFormBlocAndAutoValidateToGroupFieldBloc extends GroupFieldBlocEvent {
   List<Object?> get props => [formBloc, autoValidate];
 }
 
+class RemoveFormBlocToGroupFieldBloc extends GroupFieldBlocEvent {
+  final FormBloc<dynamic, dynamic>? formBloc;
+
+  RemoveFormBlocToGroupFieldBloc({required this.formBloc});
+
+  @override
+  List<Object?> get props => [formBloc];
+}
+
 class GroupFieldBlocState extends Equatable {
   final String name;
   final Map<String, FieldBloc> _fieldBlocs;
@@ -34,12 +43,12 @@ class GroupFieldBlocState extends Equatable {
         );
 
   GroupFieldBlocState _copyWith({
-    FormBloc? formBloc,
+    Optional<FormBloc?>? formBloc,
   }) {
     return GroupFieldBlocState(
       name: name,
       fieldBlocs: _fieldBlocs.values.toList(),
-      formBloc: formBloc ?? this.formBloc,
+      formBloc: formBloc == null ? this.formBloc : formBloc.orNull,
     );
   }
 
@@ -57,7 +66,22 @@ class GroupFieldBloc extends Bloc<GroupFieldBlocEvent, GroupFieldBlocState>
   Stream<GroupFieldBlocState> mapEventToState(
       GroupFieldBlocEvent event) async* {
     if (event is AddFormBlocAndAutoValidateToGroupFieldBloc) {
-      yield state._copyWith(formBloc: event.formBloc);
+      yield state._copyWith(formBloc: Optional.fromNullable(event.formBloc));
+
+      FormBlocUtils.addFormBlocAndAutoValidateToFieldBlocs(
+        fieldBlocs: state._fieldBlocs.values.toList(),
+        formBloc: event.formBloc,
+        autoValidate: event.autoValidate,
+      );
+    } else if (event is RemoveFormBlocToGroupFieldBloc) {
+      if (state.formBloc == event.formBloc) {
+        yield state._copyWith(formBloc: Optional.absent());
+      }
+
+      FormBlocUtils.removeFormBlocToFieldBlocs(
+        fieldBlocs: state._fieldBlocs.values.toList(),
+        formBloc: event.formBloc,
+      );
     }
   }
 

--- a/packages/form_bloc/lib/src/blocs/group_field/group_field_bloc.dart
+++ b/packages/form_bloc/lib/src/blocs/group_field/group_field_bloc.dart
@@ -116,8 +116,7 @@ class GroupFieldBloc<T extends FieldBloc, ExtraData>
         fieldBlocs: state._fieldBlocs.values.toList(),
         formBloc: event.formBloc,
       );
-    }
-    else if (event is UpdateExtraDataToGroupFieldBloc<ExtraData>) {
+    } else if (event is UpdateExtraDataToGroupFieldBloc<ExtraData>) {
       yield state._copyWith(
         extraData: Optional.fromNullable(event.extraData),
       );

--- a/packages/form_bloc/lib/src/blocs/input_field/input_field_state.dart
+++ b/packages/form_bloc/lib/src/blocs/input_field/input_field_state.dart
@@ -35,7 +35,7 @@ class InputFieldBlocState<Value, ExtraData>
       Optional<Suggestions<Value>>? suggestions,
       bool? isValidated,
       bool? isValidating,
-      FormBloc? formBloc,
+      Optional<FormBloc?>? formBloc,
       Optional<ExtraData?>? extraData}) {
     return InputFieldBlocState(
       value: value == null ? this.value : value.orNull,
@@ -44,7 +44,7 @@ class InputFieldBlocState<Value, ExtraData>
       suggestions: suggestions == null ? this.suggestions : suggestions.orNull,
       isValidated: isValidated ?? this.isValidated,
       isValidating: isValidating ?? this.isValidating,
-      formBloc: formBloc ?? this.formBloc,
+      formBloc: formBloc == null ? this.formBloc : formBloc.orNull,
       name: name,
       toJson: _toJson,
       extraData: extraData == null ? this.extraData : extraData.orNull,

--- a/packages/form_bloc/lib/src/blocs/list_field/list_field_bloc.dart
+++ b/packages/form_bloc/lib/src/blocs/list_field/list_field_bloc.dart
@@ -61,6 +61,7 @@ class RemoveFormBlocToListFieldBloc extends ListFieldBlocEvent {
   @override
   List<Object?> get props => [formBloc];
 }
+
 class ListFieldBlocState<T extends FieldBloc, ExtraData> extends Equatable {
   final String name;
   final List<T> fieldBlocs;
@@ -76,7 +77,7 @@ class ListFieldBlocState<T extends FieldBloc, ExtraData> extends Equatable {
 
   ListFieldBlocState<T, ExtraData> _copyWith({
     List<T>? fieldBlocs,
-    FormBloc? formBloc,
+    Optional<FormBloc?>? formBloc,
     Optional<ExtraData>? extraData,
   }) {
     return ListFieldBlocState(
@@ -104,7 +105,8 @@ class ListFieldBlocState<T extends FieldBloc, ExtraData> extends Equatable {
 }
 
 class ListFieldBloc<T extends FieldBloc, ExtraData>
-    extends Bloc<ListFieldBlocEvent, ListFieldBlocState<T, ExtraData>> with FieldBloc {
+    extends Bloc<ListFieldBlocEvent, ListFieldBlocState<T, ExtraData>>
+    with FieldBloc {
   bool _autoValidate = true;
 
   ListFieldBloc({
@@ -120,12 +122,15 @@ class ListFieldBloc<T extends FieldBloc, ExtraData>
 
   List<T> get value => state.fieldBlocs;
 
-  void addFieldBloc(T fieldBloc) => add(AddFieldBlocsToListFieldBloc<T>([fieldBloc]));
+  void addFieldBloc(T fieldBloc) =>
+      add(AddFieldBlocsToListFieldBloc<T>([fieldBloc]));
 
-  void addFieldBlocs(List<T> fieldBlocs) => add(AddFieldBlocsToListFieldBloc<T>(fieldBlocs));
+  void addFieldBlocs(List<T> fieldBlocs) =>
+      add(AddFieldBlocsToListFieldBloc<T>(fieldBlocs));
 
   /// Removes the [FieldBloc] in the [index].
-  void removeFieldBlocAt(int index) => add(RemoveFieldBlocAtFromListFieldBloc(index));
+  void removeFieldBlocAt(int index) =>
+      add(RemoveFieldBlocAtFromListFieldBloc(index));
 
   /// Removes all [FieldBloc]s that satisfy [test].
   void removeFieldBlocsWhere(bool Function(T element) test) =>
@@ -135,19 +140,21 @@ class ListFieldBloc<T extends FieldBloc, ExtraData>
       add(UpdateExtraDataToListFieldBloc<ExtraData>(extraData));
 
   @override
-  Stream<ListFieldBlocState<T, ExtraData>> mapEventToState(ListFieldBlocEvent event) async* {
+  Stream<ListFieldBlocState<T, ExtraData>> mapEventToState(
+      ListFieldBlocEvent event) async* {
     if (event is AddFieldBlocsToListFieldBloc<T>) {
       final stateSnapshot = state;
       if (event.fieldBlocs.isNotEmpty) {
         final newState = stateSnapshot._copyWith(
-          fieldBlocs: List<T>.from(stateSnapshot.fieldBlocs)..addAll(event.fieldBlocs),
+          fieldBlocs: List<T>.from(stateSnapshot.fieldBlocs)
+            ..addAll(event.fieldBlocs),
         );
 
         yield newState;
 
         if (state.formBloc != null) {
           FormBlocUtils.addFormBlocAndAutoValidateToFieldBlocs(
-            fieldBlocs: event.fieldBloc!,
+            fieldBlocs: event.fieldBlocs,
             formBloc: state.formBloc,
             autoValidate: _autoValidate,
           );
@@ -205,17 +212,13 @@ class ListFieldBloc<T extends FieldBloc, ExtraData>
         formBloc: event.formBloc,
         autoValidate: _autoValidate,
       );
-    }
-    else if (event is UpdateExtraDataToListFieldBloc<ExtraData>) {
+    } else if (event is UpdateExtraDataToListFieldBloc<ExtraData>) {
       yield state._copyWith(
         extraData: Optional.fromNullable(event.extraData),
       );
-    }
-    else if (event is RemoveFormBlocToListFieldBloc) {
+    } else if (event is RemoveFormBlocToListFieldBloc) {
       if (state.formBloc == event.formBloc) {
         yield state._copyWith(formBloc: Optional.absent());
-      }
-
       }
       FormBlocUtils.removeFormBlocToFieldBlocs(
         fieldBlocs: state.fieldBlocs,

--- a/packages/form_bloc/lib/src/blocs/multi_select_field/multi_select_field_state.dart
+++ b/packages/form_bloc/lib/src/blocs/multi_select_field/multi_select_field_state.dart
@@ -37,7 +37,7 @@ class MultiSelectFieldBlocState<Value, ExtraData>
       Optional<Suggestions<Value>>? suggestions,
       bool? isValidated,
       bool? isValidating,
-      FormBloc? formBloc,
+      Optional<FormBloc?>? formBloc,
       Optional<List<Value>>? items,
       Optional<ExtraData?>? extraData}) {
     return MultiSelectFieldBlocState(
@@ -47,7 +47,7 @@ class MultiSelectFieldBlocState<Value, ExtraData>
       suggestions: suggestions == null ? this.suggestions : suggestions.orNull,
       isValidated: isValidated ?? this.isValidated,
       isValidating: isValidating ?? this.isValidating,
-      formBloc: formBloc ?? this.formBloc,
+      formBloc: formBloc == null ? this.formBloc : formBloc.orNull,
       name: name,
       items: items == null ? this.items : items.orNull,
       toJson: _toJson,

--- a/packages/form_bloc/lib/src/blocs/select_field/select_field_state.dart
+++ b/packages/form_bloc/lib/src/blocs/select_field/select_field_state.dart
@@ -37,7 +37,7 @@ class SelectFieldBlocState<Value, ExtraData>
       Optional<Suggestions<Value>>? suggestions,
       bool? isValidated,
       bool? isValidating,
-      FormBloc? formBloc,
+      Optional<FormBloc?>? formBloc,
       Optional<List<Value>>? items,
       Optional<ExtraData?>? extraData}) {
     return SelectFieldBlocState(
@@ -47,7 +47,7 @@ class SelectFieldBlocState<Value, ExtraData>
       suggestions: suggestions == null ? this.suggestions : suggestions.orNull,
       isValidated: isValidated ?? this.isValidated,
       isValidating: isValidating ?? this.isValidating,
-      formBloc: formBloc ?? this.formBloc,
+      formBloc: formBloc == null ? this.formBloc : formBloc.orNull,
       name: name,
       items: items == null ? this.items : items.orNull,
       toJson: _toJson,

--- a/packages/form_bloc/lib/src/blocs/text_field/text_field_state.dart
+++ b/packages/form_bloc/lib/src/blocs/text_field/text_field_state.dart
@@ -45,7 +45,7 @@ class TextFieldBlocState<ExtraData>
       Optional<Suggestions<String>>? suggestions,
       bool? isValidated,
       bool? isValidating,
-      FormBloc? formBloc,
+        Optional<FormBloc?>? formBloc,
       Optional<ExtraData?>? extraData}) {
     return TextFieldBlocState(
       value: value == null ? this.value : value.orNull,
@@ -54,7 +54,7 @@ class TextFieldBlocState<ExtraData>
       suggestions: suggestions == null ? this.suggestions : suggestions.orNull,
       isValidated: isValidated ?? this.isValidated,
       isValidating: isValidating ?? this.isValidating,
-      formBloc: formBloc ?? this.formBloc,
+      formBloc: formBloc == null ? this.formBloc : formBloc.orNull,
       name: name,
       toJson: _toJson,
       extraData: extraData == null ? this.extraData : extraData.orNull,

--- a/packages/form_bloc/test/form_bloc/form_bloc_utils_test.dart
+++ b/packages/form_bloc/test/form_bloc/form_bloc_utils_test.dart
@@ -15,6 +15,11 @@ class GroupFieldBlocImpl extends GroupFieldBloc {
   }
 }
 
+class FormBlocImpl extends FormBloc<dynamic, dynamic> {
+  @override
+  void onSubmitting() {}
+}
+
 void main() {
   group('FormBlocUtils:', () {
     group('getAllSingleFieldBlocs:', () {
@@ -780,6 +785,117 @@ void main() {
         ];
 
         print(FormBlocUtils.fieldBlocsStatesListToJsonList(fieldBlocList));
+      });
+    });
+
+    group('addFormBlocAndAutoValidateToFieldBlocs & removeFormBlocToFieldBlocs',
+        () {
+      test('SingleFieldBloc', () async {
+        final formBloc = FormBlocImpl();
+
+        final listFieldBloc = BooleanFieldBloc<dynamic>(name: '');
+
+        FormBlocUtils.addFormBlocAndAutoValidateToFieldBlocs(
+          fieldBlocs: [listFieldBloc],
+          formBloc: formBloc,
+        );
+
+        await expectLater(
+          listFieldBloc.stream,
+          emitsInOrder(<BooleanFieldBlocState<dynamic>>[
+            BooleanFieldBlocState<dynamic>(
+              name: '',
+              formBloc: formBloc,
+              value: false,
+              error: null,
+              isInitial: true,
+              suggestions: null,
+              isValidated: false,
+              isValidating: false,
+            ),
+          ]),
+        );
+
+        FormBlocUtils.removeFormBlocToFieldBlocs(
+          fieldBlocs: [listFieldBloc],
+          formBloc: formBloc,
+        );
+
+        await expectLater(
+          listFieldBloc.stream,
+          emitsInOrder(<BooleanFieldBlocState>[
+            BooleanFieldBlocState<dynamic>(
+              name: '',
+              formBloc: null,
+              value: false,
+              error: null,
+              isInitial: true,
+              suggestions: null,
+              isValidated: false,
+              isValidating: false,
+            ),
+          ]),
+        );
+      });
+
+      test('ListFieldBloc', () async {
+        final formBloc = FormBlocImpl();
+
+        final listFieldBloc = ListFieldBloc(name: '');
+
+        FormBlocUtils.addFormBlocAndAutoValidateToFieldBlocs(
+          fieldBlocs: [listFieldBloc],
+          formBloc: formBloc,
+        );
+
+        await expectLater(
+          listFieldBloc.stream,
+          emitsInOrder(<ListFieldBlocState>[
+            ListFieldBlocState(name: '', fieldBlocs: [], formBloc: formBloc),
+          ]),
+        );
+
+        FormBlocUtils.removeFormBlocToFieldBlocs(
+          fieldBlocs: [listFieldBloc],
+          formBloc: formBloc,
+        );
+
+        await expectLater(
+          listFieldBloc.stream,
+          emitsInOrder(<ListFieldBlocState>[
+            ListFieldBlocState(name: '', fieldBlocs: [], formBloc: null),
+          ]),
+        );
+      });
+
+      test('GroupFieldBloc', () async {
+        final formBloc = FormBlocImpl();
+
+        final listFieldBloc = GroupFieldBloc([], name: '');
+
+        FormBlocUtils.addFormBlocAndAutoValidateToFieldBlocs(
+          fieldBlocs: [listFieldBloc],
+          formBloc: formBloc,
+        );
+
+        await expectLater(
+          listFieldBloc.stream,
+          emitsInOrder(<GroupFieldBlocState>[
+            GroupFieldBlocState(name: '', fieldBlocs: [], formBloc: formBloc),
+          ]),
+        );
+
+        FormBlocUtils.removeFormBlocToFieldBlocs(
+          fieldBlocs: [listFieldBloc],
+          formBloc: formBloc,
+        );
+
+        await expectLater(
+          listFieldBloc.stream,
+          emitsInOrder(<GroupFieldBlocState>[
+            GroupFieldBlocState(name: '', fieldBlocs: [], formBloc: null),
+          ]),
+        );
       });
     });
   });

--- a/packages/form_bloc/test/form_bloc/form_bloc_utils_test.dart
+++ b/packages/form_bloc/test/form_bloc/form_bloc_utils_test.dart
@@ -89,10 +89,13 @@ void main() {
         extraData: null,
       );
 
-      final booleanFieldBloc1 = BooleanFieldBloc<dynamic>(name: 'booleanFieldBloc1');
-      final booleanFieldBloc2 = BooleanFieldBloc<dynamic>(name: 'booleanFieldBloc2');
+      final booleanFieldBloc1 =
+          BooleanFieldBloc<dynamic>(name: 'booleanFieldBloc1');
+      final booleanFieldBloc2 =
+          BooleanFieldBloc<dynamic>(name: 'booleanFieldBloc2');
 
-      final fieldBlocListWithSingleFieldBlocs1 = ListFieldBloc<FieldBloc, dynamic>(
+      final fieldBlocListWithSingleFieldBlocs1 =
+          ListFieldBloc<FieldBloc, dynamic>(
         name: 'fieldBlocListWithSingleFieldBlocs1',
         fieldBlocs: [
           booleanFieldBloc1,
@@ -100,14 +103,16 @@ void main() {
         ],
       );
 
-      final selectFieldBloc1 = SelectFieldBloc<String, dynamic>(name: 'selectFieldBloc1');
+      final selectFieldBloc1 =
+          SelectFieldBloc<String, dynamic>(name: 'selectFieldBloc1');
       final multiSelectFieldBloc1 =
           MultiSelectFieldBloc<String, dynamic>(name: 'multiSelectFieldBloc1');
 
       final multiSelectFieldBloc3 =
           MultiSelectFieldBloc<String, dynamic>(name: 'booleanFieldBloc3');
       final textFieldBloc9 = TextFieldBloc<dynamic>(name: 'textFieldBloc9');
-      final inputFieldBloc1 = InputFieldBloc<int, dynamic>(name: 'inputFieldBloc1');
+      final inputFieldBloc1 =
+          InputFieldBloc<int, dynamic>(name: 'inputFieldBloc1');
 
       final groupFieldBlocWithAll1 = GroupFieldBlocImpl(
         name: 'groupFieldBlocWithAll1',
@@ -217,7 +222,8 @@ void main() {
           booleanFieldBloc2,
         ];
 
-        final singleFieldBlocs = FormBlocUtils.getAllSingleFieldBlocs(fieldBlocs);
+        final singleFieldBlocs =
+            FormBlocUtils.getAllSingleFieldBlocs(fieldBlocs);
 
         expect(
           singleFieldBlocs,
@@ -226,14 +232,16 @@ void main() {
       });
 
       test('Empty FieldBlocList', () {
-        final fieldBlocList21 = ListFieldBloc<FieldBloc, dynamic>(name: 'list21');
+        final fieldBlocList21 =
+            ListFieldBloc<FieldBloc, dynamic>(name: 'list21');
 
         final fieldBlocs = <FieldBloc>[
           fieldBlocList21,
         ];
         final expectedSingleFieldBlocs = <SingleFieldBloc>[];
 
-        final singleFieldBlocs = FormBlocUtils.getAllSingleFieldBlocs(fieldBlocs);
+        final singleFieldBlocs =
+            FormBlocUtils.getAllSingleFieldBlocs(fieldBlocs);
 
         expect(
           singleFieldBlocs,
@@ -260,7 +268,8 @@ void main() {
           multiSelectFieldBloc3
         ];
 
-        final singleFieldBlocs = FormBlocUtils.getAllSingleFieldBlocs(fieldBlocs);
+        final singleFieldBlocs =
+            FormBlocUtils.getAllSingleFieldBlocs(fieldBlocs);
 
         expect(
           singleFieldBlocs,
@@ -283,7 +292,8 @@ void main() {
           booleanFieldBloc2,
         ];
 
-        final singleFieldBlocs = FormBlocUtils.getAllSingleFieldBlocs(fieldBlocs);
+        final singleFieldBlocs =
+            FormBlocUtils.getAllSingleFieldBlocs(fieldBlocs);
 
         expect(
           singleFieldBlocs,
@@ -300,7 +310,8 @@ void main() {
           textFieldBloc4,
         ];
 
-        final singleFieldBlocs = FormBlocUtils.getAllSingleFieldBlocs(fieldBlocs);
+        final singleFieldBlocs =
+            FormBlocUtils.getAllSingleFieldBlocs(fieldBlocs);
 
         expect(
           singleFieldBlocs,
@@ -324,7 +335,8 @@ void main() {
           textFieldBloc4,
         ];
 
-        final singleFieldBlocs = FormBlocUtils.getAllSingleFieldBlocs(fieldBlocs);
+        final singleFieldBlocs =
+            FormBlocUtils.getAllSingleFieldBlocs(fieldBlocs);
 
         expect(
           singleFieldBlocs,
@@ -334,13 +346,15 @@ void main() {
     });
 
     final booleanFieldBloc1 = BooleanFieldBloc<dynamic>(name: 'boolean1');
-    final textFieldBloc1 = TextFieldBloc<dynamic>(name: 'textFieldBloc1', initialValue: 'text1');
+    final textFieldBloc1 =
+        TextFieldBloc<dynamic>(name: 'textFieldBloc1', initialValue: 'text1');
 
     final booleanFieldBloc2 = BooleanFieldBloc<dynamic>(name: 'boolean2');
-    final textFieldBloc2 = TextFieldBloc<dynamic>(name: 'textFieldBloc2', initialValue: 'text2');
+    final textFieldBloc2 =
+        TextFieldBloc<dynamic>(name: 'textFieldBloc2', initialValue: 'text2');
 
-    final groupFieldBloc1 =
-        GroupFieldBlocImpl(name: 'group1', fieldBlocs: [booleanFieldBloc1], extraData: null);
+    final groupFieldBloc1 = GroupFieldBlocImpl(
+        name: 'group1', fieldBlocs: [booleanFieldBloc1], extraData: null);
 
     final fieldBlocList1 = ListFieldBloc<FieldBloc, dynamic>(
         name: 'list1', fieldBlocs: [booleanFieldBloc1, textFieldBloc1]);
@@ -351,14 +365,14 @@ void main() {
     final fieldBlocList3 = ListFieldBloc<FieldBloc, dynamic>(
         name: 'list3', fieldBlocs: [fieldBlocList1, fieldBlocList2]);
 
-    final groupFieldBloc2 =
-        GroupFieldBlocImpl(name: 'group2', fieldBlocs: [fieldBlocList3], extraData: null);
+    final groupFieldBloc2 = GroupFieldBlocImpl(
+        name: 'group2', fieldBlocs: [fieldBlocList3], extraData: null);
 
-    final groupFieldBloc3 =
-        GroupFieldBlocImpl(name: 'group3', fieldBlocs: [groupFieldBloc2], extraData: null);
+    final groupFieldBloc3 = GroupFieldBlocImpl(
+        name: 'group3', fieldBlocs: [groupFieldBloc2], extraData: null);
 
-    final fieldBlocList4 =
-        ListFieldBloc<FieldBloc, dynamic>(name: 'list4', fieldBlocs: [groupFieldBloc3]);
+    final fieldBlocList4 = ListFieldBloc<FieldBloc, dynamic>(
+        name: 'list4', fieldBlocs: [groupFieldBloc3]);
     group('getFieldBlocFromPath', () {
       test('First name of path is a SingleFieldBloc', () {
         final fieldBlocs = <String, FieldBloc>{
@@ -529,7 +543,9 @@ void main() {
         expect(fieldBloc, null);
       });
 
-      test('Returns null if has a path that exist and after has a path that not exist', () {
+      test(
+          'Returns null if has a path that exist and after has a path that not exist',
+          () {
         final fieldBlocs = <String, FieldBloc>{
           booleanFieldBloc1.state.name!: booleanFieldBloc1,
         };
@@ -719,7 +735,8 @@ void main() {
           textFieldBloc1.state.name!: textFieldBloc1,
         };
 
-        final fieldBlocsStates = FormBlocUtils.fieldBlocsToFieldBlocsStates(fieldBlocs);
+        final fieldBlocsStates =
+            FormBlocUtils.fieldBlocsToFieldBlocsStates(fieldBlocs);
 
         print(
           fieldBlocsStates,
@@ -735,13 +752,15 @@ void main() {
         textFieldBloc1.state.name!: textFieldBloc1,
       };
 
-      final fieldBlocsStates = FormBlocUtils.fieldBlocsToFieldBlocsStates(fieldBlocs);
+      final fieldBlocsStates =
+          FormBlocUtils.fieldBlocsToFieldBlocsStates(fieldBlocs);
       // TODO: Add more tests
       test('Root SingleFieldBloc', () {
         expect(
             textFieldBloc1.state,
             FormBlocUtils.getFieldBlocStateFromPath(
-                path: textFieldBloc1.state.name, fieldBlocsStates: fieldBlocsStates));
+                path: textFieldBloc1.state.name,
+                fieldBlocsStates: fieldBlocsStates));
       });
     });
 
@@ -754,7 +773,8 @@ void main() {
           textFieldBloc1.state.name!: textFieldBloc1,
         };
 
-        final fieldBlocsStates = FormBlocUtils.fieldBlocsToFieldBlocsStates(fieldBlocs);
+        final fieldBlocsStates =
+            FormBlocUtils.fieldBlocsToFieldBlocsStates(fieldBlocs);
 
         print(
           JsonEncoder.withIndent('    ').convert(
@@ -829,7 +849,7 @@ void main() {
       test('ListFieldBloc', () async {
         final formBloc = FormBlocImpl();
 
-        final listFieldBloc = ListFieldBloc(name: '');
+        final listFieldBloc = ListFieldBloc<FieldBloc, dynamic>(name: '');
 
         FormBlocUtils.addFormBlocAndAutoValidateToFieldBlocs(
           fieldBlocs: [listFieldBloc],
@@ -838,8 +858,9 @@ void main() {
 
         await expectLater(
           listFieldBloc.stream,
-          emitsInOrder(<ListFieldBlocState>[
-            ListFieldBlocState(name: '', fieldBlocs: [], formBloc: formBloc),
+          emitsInOrder(<ListFieldBlocState<FieldBloc, dynamic>>[
+            ListFieldBlocState<FieldBloc, dynamic>(
+                name: '', fieldBlocs: [], formBloc: formBloc, extraData: null),
           ]),
         );
 
@@ -851,7 +872,8 @@ void main() {
         await expectLater(
           listFieldBloc.stream,
           emitsInOrder(<ListFieldBlocState>[
-            ListFieldBlocState(name: '', fieldBlocs: [], formBloc: null),
+            ListFieldBlocState<FieldBloc, dynamic>(
+                name: '', fieldBlocs: [], formBloc: null, extraData: null),
           ]),
         );
       });
@@ -859,7 +881,8 @@ void main() {
       test('GroupFieldBloc', () async {
         final formBloc = FormBlocImpl();
 
-        final listFieldBloc = GroupFieldBloc([], name: '');
+        final listFieldBloc =
+            GroupFieldBlocImpl(name: '', fieldBlocs: [], extraData: null);
 
         FormBlocUtils.addFormBlocAndAutoValidateToFieldBlocs(
           fieldBlocs: [listFieldBloc],
@@ -869,7 +892,8 @@ void main() {
         await expectLater(
           listFieldBloc.stream,
           emitsInOrder(<GroupFieldBlocState>[
-            GroupFieldBlocState(name: '', fieldBlocs: [], formBloc: formBloc),
+            GroupFieldBlocState<FieldBloc, dynamic>(
+                name: '', fieldBlocs: [], formBloc: formBloc, extraData: null),
           ]),
         );
 
@@ -881,7 +905,8 @@ void main() {
         await expectLater(
           listFieldBloc.stream,
           emitsInOrder(<GroupFieldBlocState>[
-            GroupFieldBlocState(name: '', fieldBlocs: [], formBloc: null),
+            GroupFieldBlocState<FieldBloc, dynamic>(
+                name: '', fieldBlocs: [], formBloc: null, extraData: null),
           ]),
         );
       });


### PR DESCRIPTION
… when it was removed from the FormBloc

- Now when you remove a field bloc from FormBloc, ListFieldBloc or GroupFieldBloc it removes the FormBloc in all corresponding children

Removed FieldBlocs should not be closed as they may be re-added very soon