### PR TITLE
Fix field animation appear and more fixs

### DIFF
--- a/packages/flutter_form_bloc/example/lib/main.dart
+++ b/packages/flutter_form_bloc/example/lib/main.dart
@@ -155,7 +155,6 @@ class AllFieldsForm extends StatelessWidget {
                           selectFieldBloc: formBloc.select1,
                           decoration: InputDecoration(
                             labelText: 'DropdownFieldBlocBuilder',
-                            prefixIcon: Icon(Icons.sentiment_satisfied),
                           ),
                           itemBuilder: (context, value) => FieldItem(
                             isEnabled: value != 'Option 1',

--- a/packages/flutter_form_bloc/lib/src/dropdown_field_bloc_builder.dart
+++ b/packages/flutter_form_bloc/lib/src/dropdown_field_bloc_builder.dart
@@ -178,9 +178,16 @@ class DropdownFieldBlocBuilder<Value> extends StatelessWidget {
                     // Simulates the normal alignment of the suffixIcon
                     icon: Transform.translate(
                       offset: Offset(6.0, 0.0),
-                      child: decoration.suffixIcon ??
-                          fieldTheme.moreIcon ??
-                          const Icon(Icons.arrow_drop_down),
+                      child: ConstrainedBox(
+                        constraints: this.decoration.suffixIconConstraints ??
+                            const BoxConstraints(
+                              minHeight: 48.0,
+                              minWidth: 48.0,
+                            ),
+                        child: this.decoration.suffixIcon ??
+                            fieldTheme.moreIcon ??
+                            const Icon(Icons.arrow_drop_down),
+                      ),
                     ),
                   ),
                 ),
@@ -255,6 +262,9 @@ class DropdownFieldBlocBuilder<Value> extends StatelessWidget {
     decoration = decoration.copyWith(
       enabled: isEnabled,
       contentPadding: const EdgeInsets.only(left: 16.0),
+      suffix: const SizedBox.shrink(),
+      suffixIcon: const SizedBox.shrink(),
+      suffixIconConstraints: const BoxConstraints(),
       errorText: Style.getErrorText(
         context: context,
         errorBuilder: errorBuilder,

--- a/packages/flutter_form_bloc/lib/src/text_field_bloc_builder.dart
+++ b/packages/flutter_form_bloc/lib/src/text_field_bloc_builder.dart
@@ -991,6 +991,7 @@ class _TextFieldBlocBuilderState extends State<TextFieldBlocBuilder> {
       removeSuggestionOnLongPress: widget.removeSuggestionOnLongPress,
       suggestionsBoxDecoration: widget.suggestionsBoxDecoration ??
           SuggestionsBoxDecoration(
+            constraints: const BoxConstraints(minHeight: _kMenuItemHeight),
             borderRadius: BorderRadius.circular(4),
             color: Theme.of(context).canvasColor,
           ),

--- a/packages/flutter_form_bloc/lib/src/theme/form_bloc_theme.dart
+++ b/packages/flutter_form_bloc/lib/src/theme/form_bloc_theme.dart
@@ -157,6 +157,18 @@ class DateTimeFieldTheme extends FieldTheme {
 
 /// The theme of [DropdownFieldBlocBuilder]
 class DropdownFieldTheme extends FieldTheme {
+  /// Defaults is [TextOverflow.ellipsis]
+  final TextOverflow? textOverflow;
+
+  /// Defaults is `1`
+  final int? maxLines;
+
+  /// Defaults is [FieldTheme.textStyle]
+  final TextStyle? selectedTextStyle;
+
+  /// Defaults is [DropdownFieldTheme.maxLines]
+  final int? selectedMaxLines;
+
   /// Defaults is [Icons.arrow_drop_down]
   final Widget? moreIcon;
 
@@ -164,6 +176,10 @@ class DropdownFieldTheme extends FieldTheme {
     TextStyle? textStyle,
     MaterialStateProperty<Color?>? textColor,
     InputDecorationTheme? decorationTheme,
+    this.textOverflow,
+    this.maxLines,
+    this.selectedTextStyle,
+    this.selectedMaxLines,
     this.moreIcon,
   }) : super(
           textStyle: textStyle,
@@ -175,12 +191,20 @@ class DropdownFieldTheme extends FieldTheme {
     TextStyle? textStyle,
     MaterialStateProperty<Color?>? textColor,
     InputDecorationTheme? decorationTheme,
+    TextOverflow? textOverflow,
+    int? maxLines,
+    TextStyle? selectedTextStyle,
+    int? selectedMaxLines,
     Widget? moreIcon,
   }) {
     return DropdownFieldTheme(
       textStyle: textStyle ?? this.textStyle,
       textColor: textColor ?? this.textColor,
       decorationTheme: decorationTheme ?? this.decorationTheme,
+      textOverflow: textOverflow ?? this.textOverflow,
+      maxLines: maxLines ?? this.maxLines,
+      selectedTextStyle: selectedTextStyle ?? this.selectedTextStyle,
+      selectedMaxLines: selectedMaxLines ?? this.selectedMaxLines,
       moreIcon: moreIcon ?? this.moreIcon,
     );
   }

--- a/packages/flutter_form_bloc/lib/src/theme/material_states.dart
+++ b/packages/flutter_form_bloc/lib/src/theme/material_states.dart
@@ -14,4 +14,9 @@ class SimpleMaterialStateProperty<T> implements MaterialStateProperty<T> {
     if (states.contains(MaterialState.disabled)) return disabled;
     return normal;
   }
+
+  @override
+  String toString() {
+    return 'SimpleMaterialStateProperty{normal: $normal, disabled: $disabled}';
+  }
 }

--- a/packages/form_bloc/lib/src/blocs/field/field_bloc.dart
+++ b/packages/form_bloc/lib/src/blocs/field/field_bloc.dart
@@ -50,12 +50,18 @@ typedef Suggestions<Value> = Future<List<Value>> Function(String pattern);
 ///   * [MultiSelectFieldBloc].
 /// * [GroupFieldBloc].
 /// * [ListFieldBloc].
-abstract class FieldBloc {
+mixin FieldBloc<State extends FieldBlocStateBase> on BlocBase<State> {
   /// Update the [formBloc] and [autoValidate] to the fieldBloc
   void updateFormBloc(FormBloc formBloc, {bool autoValidate = false});
 
   /// Remove the [formBloc] to the fieldBloc
   void removeFormBloc(FormBloc formBloc);
+}
+
+/// The common state interface of all field blocs
+abstract class FieldBlocStateBase {
+  /// Identifies whether the FieldBloc has been added to the FormBloc
+  FormBloc? get formBloc;
 }
 
 /// The base class with the common behavior

--- a/packages/form_bloc/lib/src/blocs/field/field_state.dart
+++ b/packages/form_bloc/lib/src/blocs/field/field_state.dart
@@ -1,6 +1,7 @@
 part of 'field_bloc.dart';
 
-abstract class FieldBlocState<Value, Suggestion, ExtraData> extends Equatable {
+abstract class FieldBlocState<Value, Suggestion, ExtraData> extends Equatable
+    implements FieldBlocStateBase {
   /// The current value of this state.
   final Value value;
 
@@ -31,6 +32,7 @@ abstract class FieldBlocState<Value, Suggestion, ExtraData> extends Equatable {
   final bool isValidating;
 
   /// The current  [FormBloc] that contains this `FieldBloc`.
+  @override
   final FormBloc? formBloc;
 
   /// Transform [value] in a JSON value.

--- a/packages/form_bloc/lib/src/blocs/group_field/group_field_bloc.dart
+++ b/packages/form_bloc/lib/src/blocs/group_field/group_field_bloc.dart
@@ -1,9 +1,11 @@
 part of '../field/field_bloc.dart';
 
-class GroupFieldBlocState<T extends FieldBloc, ExtraData> extends Equatable {
+class GroupFieldBlocState<T extends FieldBloc, ExtraData> extends Equatable
+    implements FieldBlocStateBase {
   final String name;
   final Map<String, T> _fieldBlocs;
   final ExtraData? extraData;
+  @override
   final FormBloc? formBloc;
 
   GroupFieldBlocState({

--- a/packages/form_bloc/lib/src/blocs/list_field/list_field_bloc.dart
+++ b/packages/form_bloc/lib/src/blocs/list_field/list_field_bloc.dart
@@ -1,9 +1,11 @@
 part of '../field/field_bloc.dart';
 
-class ListFieldBlocState<T extends FieldBloc, ExtraData> extends Equatable {
+class ListFieldBlocState<T extends FieldBloc, ExtraData> extends Equatable
+    implements FieldBlocStateBase {
   final String name;
   final List<T> fieldBlocs;
   final ExtraData? extraData;
+  @override
   final FormBloc? formBloc;
 
   ListFieldBlocState({


### PR DESCRIPTION
- Fixed duplication of dropdown icon
- Fixed the animation of the pop-up of the suggestions list, now it is smoother
- Fixed animation not working if the FieldBloc was already in the `FormBloc`
- Added `FieldBlocStateBase` to have a common state between `FieldBloc`
- Aligned the style of the `DropdownFieldBlocBuilder` to the style of `DropdownButtonFormField`
- Now you can customize the dropdown theme more
- Fix emptyItemLabel style when dropdown is open

Should you rename?
- `FieldBlocState` -> `SingleFieldBlocState`
- `FieldBlocStateBase` -> `FieldBlocState`

Can you release a version with all the changes? Because in the latest version there are a lot of commits missing
