### PR TITLE
Align packages to `lints` and `flutter_lints`

### DIFF
--- a/packages/flutter_form_bloc/analysis_options.yaml
+++ b/packages/flutter_form_bloc/analysis_options.yaml
@@ -1,1 +1,11 @@
-include: package:pedantic/analysis_options.1.7.0.yaml
+include: package:flutter_lints/flutter.yaml
+
+analyzer:
+  errors:
+    avoid_print: warning
+    annotate_overrides: warning
+    always_use_package_imports: warning
+
+linter:
+  rules:
+    always_use_package_imports: true

--- a/packages/flutter_form_bloc/example/lib/main.dart
+++ b/packages/flutter_form_bloc/example/lib/main.dart
@@ -4,7 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_form_bloc/flutter_form_bloc.dart';
 
 void main() {
-  runApp(App());
+  runApp(const App());
 }
 
 class App extends StatelessWidget {
@@ -12,7 +12,7 @@ class App extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp(
+    return const MaterialApp(
       debugShowCheckedModeBanner: false,
       home: AllFieldsForm(),
     );
@@ -77,7 +77,7 @@ class AllFieldsFormBloc extends FormBloc<String, String> {
   @override
   void onSubmitting() async {
     try {
-      await Future<void>.delayed(Duration(milliseconds: 500));
+      await Future<void>.delayed(const Duration(milliseconds: 500));
 
       emitSuccess(canSubmitAgain: true);
     } catch (e) {
@@ -87,6 +87,8 @@ class AllFieldsFormBloc extends FormBloc<String, String> {
 }
 
 class AllFieldsForm extends StatelessWidget {
+  const AllFieldsForm({Key? key}) : super(key: key);
+
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
@@ -104,22 +106,22 @@ class AllFieldsForm extends StatelessWidget {
               ),
             ),
             child: Scaffold(
-              appBar: AppBar(title: Text('Built-in Widgets')),
+              appBar: AppBar(title: const Text('Built-in Widgets')),
               floatingActionButton: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: <Widget>[
                   FloatingActionButton.extended(
                     heroTag: null,
                     onPressed: formBloc.addErrors,
-                    icon: Icon(Icons.error_outline),
-                    label: Text('ADD ERRORS'),
+                    icon: const Icon(Icons.error_outline),
+                    label: const Text('ADD ERRORS'),
                   ),
-                  SizedBox(height: 12),
+                  const SizedBox(height: 12),
                   FloatingActionButton.extended(
                     heroTag: null,
                     onPressed: formBloc.submit,
-                    icon: Icon(Icons.send),
-                    label: Text('SUBMIT'),
+                    icon: const Icon(Icons.send),
+                    label: const Text('SUBMIT'),
                   ),
                 ],
               ),
@@ -131,7 +133,7 @@ class AllFieldsForm extends StatelessWidget {
                   LoadingDialog.hide(context);
 
                   Navigator.of(context).pushReplacement(
-                      MaterialPageRoute(builder: (_) => SuccessScreen()));
+                      MaterialPageRoute(builder: (_) => const SuccessScreen()));
                 },
                 onFailure: (context, state) {
                   LoadingDialog.hide(context);
@@ -139,21 +141,21 @@ class AllFieldsForm extends StatelessWidget {
                       SnackBar(content: Text(state.failureResponse!)));
                 },
                 child: SingleChildScrollView(
-                  physics: ClampingScrollPhysics(),
+                  physics: const ClampingScrollPhysics(),
                   child: Padding(
                     padding: const EdgeInsets.all(24.0),
                     child: Column(
                       children: <Widget>[
                         TextFieldBlocBuilder(
                           textFieldBloc: formBloc.text1,
-                          decoration: InputDecoration(
+                          decoration: const InputDecoration(
                             labelText: 'TextFieldBlocBuilder',
                             prefixIcon: Icon(Icons.text_fields),
                           ),
                         ),
                         DropdownFieldBlocBuilder<String>(
                           selectFieldBloc: formBloc.select1,
-                          decoration: InputDecoration(
+                          decoration: const InputDecoration(
                             labelText: 'DropdownFieldBlocBuilder',
                           ),
                           itemBuilder: (context, value) => FieldItem(
@@ -163,7 +165,7 @@ class AllFieldsForm extends StatelessWidget {
                         ),
                         RadioButtonGroupFieldBlocBuilder<String>(
                           selectFieldBloc: formBloc.select2,
-                          decoration: InputDecoration(
+                          decoration: const InputDecoration(
                             labelText: 'RadioButtonGroupFieldBlocBuilder',
                           ),
                           itemBuilder: (context, item) => FieldItem(
@@ -172,7 +174,7 @@ class AllFieldsForm extends StatelessWidget {
                         ),
                         CheckboxGroupFieldBlocBuilder<String>(
                           multiSelectFieldBloc: formBloc.multiSelect1,
-                          decoration: InputDecoration(
+                          decoration: const InputDecoration(
                             labelText: 'CheckboxGroupFieldBlocBuilder',
                           ),
                           itemBuilder: (context, item) => FieldItem(
@@ -185,7 +187,7 @@ class AllFieldsForm extends StatelessWidget {
                           initialDate: DateTime.now(),
                           firstDate: DateTime(1900),
                           lastDate: DateTime(2100),
-                          decoration: InputDecoration(
+                          decoration: const InputDecoration(
                             labelText: 'DateTimeFieldBlocBuilder',
                             prefixIcon: Icon(Icons.calendar_today),
                             helperText: 'Date',
@@ -198,7 +200,7 @@ class AllFieldsForm extends StatelessWidget {
                           initialDate: DateTime.now(),
                           firstDate: DateTime(1900),
                           lastDate: DateTime(2100),
-                          decoration: InputDecoration(
+                          decoration: const InputDecoration(
                             labelText: 'DateTimeFieldBlocBuilder',
                             prefixIcon: Icon(Icons.date_range),
                             helperText: 'Date and Time',
@@ -208,18 +210,18 @@ class AllFieldsForm extends StatelessWidget {
                           timeFieldBloc: formBloc.time1,
                           format: DateFormat('hh:mm a'),
                           initialTime: TimeOfDay.now(),
-                          decoration: InputDecoration(
+                          decoration: const InputDecoration(
                             labelText: 'TimeFieldBlocBuilder',
                             prefixIcon: Icon(Icons.access_time),
                           ),
                         ),
                         SwitchFieldBlocBuilder(
                           booleanFieldBloc: formBloc.boolean2,
-                          body: Text('CheckboxFieldBlocBuilder'),
+                          body: const Text('CheckboxFieldBlocBuilder'),
                         ),
                         CheckboxFieldBlocBuilder(
                           booleanFieldBloc: formBloc.boolean1,
-                          body: Text('CheckboxFieldBlocBuilder'),
+                          body: const Text('CheckboxFieldBlocBuilder'),
                         ),
                         BlocBuilder<InputFieldBloc<File?, String>,
                                 InputFieldBlocState<File?, String>>(
@@ -250,7 +252,7 @@ class LoadingDialog extends StatelessWidget {
 
   static void hide(BuildContext context) => Navigator.pop(context);
 
-  LoadingDialog({Key? key}) : super(key: key);
+  const LoadingDialog({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -261,8 +263,8 @@ class LoadingDialog extends StatelessWidget {
           child: Container(
             width: 80,
             height: 80,
-            padding: EdgeInsets.all(12.0),
-            child: CircularProgressIndicator(),
+            padding: const EdgeInsets.all(12.0),
+            child: const CircularProgressIndicator(),
           ),
         ),
       ),
@@ -271,7 +273,7 @@ class LoadingDialog extends StatelessWidget {
 }
 
 class SuccessScreen extends StatelessWidget {
-  SuccessScreen({Key? key}) : super(key: key);
+  const SuccessScreen({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
@@ -280,19 +282,19 @@ class SuccessScreen extends StatelessWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: <Widget>[
-            Icon(Icons.tag_faces, size: 100),
-            SizedBox(height: 10),
-            Text(
+            const Icon(Icons.tag_faces, size: 100),
+            const SizedBox(height: 10),
+            const Text(
               'Success',
               style: TextStyle(fontSize: 54, color: Colors.black),
               textAlign: TextAlign.center,
             ),
-            SizedBox(height: 10),
+            const SizedBox(height: 10),
             ElevatedButton.icon(
               onPressed: () => Navigator.of(context).pushReplacement(
-                  MaterialPageRoute(builder: (_) => AllFieldsForm())),
-              icon: Icon(Icons.replay),
-              label: Text('AGAIN'),
+                  MaterialPageRoute(builder: (_) => const AllFieldsForm())),
+              icon: const Icon(Icons.replay),
+              label: const Text('AGAIN'),
             ),
           ],
         ),

--- a/packages/flutter_form_bloc/lib/src/can_show_field_bloc_builder.dart
+++ b/packages/flutter_form_bloc/lib/src/can_show_field_bloc_builder.dart
@@ -42,7 +42,7 @@ class _CanShowFieldBlocBuilderState extends State<CanShowFieldBlocBuilder>
       _showOnFirstFrame = true;
       _initVisibility();
     } else {
-      Future.delayed(Duration(milliseconds: 10)).whenComplete(() {
+      Future.delayed(const Duration(milliseconds: 10)).whenComplete(() {
         if (!mounted) return;
         setState(() {
           _showOnFirstFrame = true;

--- a/packages/flutter_form_bloc/lib/src/checkbox_group_field_bloc_builder.dart
+++ b/packages/flutter_form_bloc/lib/src/checkbox_group_field_bloc_builder.dart
@@ -152,7 +152,7 @@ class CheckboxGroupFieldBlocBuilder<Value> extends StatelessWidget {
   ) {
     return ListView.builder(
       shrinkWrap: true,
-      physics: ClampingScrollPhysics(),
+      physics: const ClampingScrollPhysics(),
       itemCount: state.items.length,
       itemBuilder: (context, index) {
         final item = state.items[index];

--- a/packages/flutter_form_bloc/lib/src/date_time/date_time_field_bloc_builder_base.dart
+++ b/packages/flutter_form_bloc/lib/src/date_time/date_time_field_bloc_builder_base.dart
@@ -131,7 +131,7 @@ class _DateTimeFieldBlocBuilderBaseState<T>
     extends State<DateTimeFieldBlocBuilderBase<T>> {
   final DatePickerMode initialDatePickerMode = DatePickerMode.day;
 
-  FocusNode _focusNode = FocusNode();
+  final FocusNode _focusNode = FocusNode();
 
   FocusNode get _effectiveFocusNode => widget.focusNode ?? _focusNode;
 
@@ -156,7 +156,7 @@ class _DateTimeFieldBlocBuilderBaseState<T>
 
   void _showPicker(BuildContext context) async {
     FocusScope.of(context).requestFocus(FocusNode());
-    var result;
+    dynamic result;
     if (widget.type == DateTimeFieldBlocBuilderBaseType.date) {
       result = await _showDatePicker(context);
     } else if (widget.type == DateTimeFieldBlocBuilderBaseType.both) {
@@ -197,7 +197,7 @@ class _DateTimeFieldBlocBuilderBaseState<T>
             bloc: widget.dateTimeFieldBloc,
             builder: (context, state) {
               final isEnabled = fieldBlocIsEnabled(
-                isEnabled: this.widget.isEnabled ?? true,
+                isEnabled: widget.isEnabled ?? true,
                 enableOnlyWhenFormBlocCanSubmit:
                     widget.enableOnlyWhenFormBlocCanSubmit,
                 fieldBlocState: state,
@@ -324,7 +324,7 @@ class _DateTimeFieldBlocBuilderBaseState<T>
     InputFieldBlocState<T, dynamic> state,
     bool isEnabled,
   ) {
-    InputDecoration decoration = this.widget.decoration;
+    InputDecoration decoration = widget.decoration;
 
     decoration = decoration.copyWith(
       enabled: isEnabled,
@@ -337,7 +337,7 @@ class _DateTimeFieldBlocBuilderBaseState<T>
       suffixIcon: decoration.suffixIcon ??
           (fieldTheme.showClearIcon!
               ? AnimatedOpacity(
-                  duration: Duration(milliseconds: 400),
+                  duration: const Duration(milliseconds: 400),
                   opacity:
                       widget.dateTimeFieldBloc.state.value == null ? 0.0 : 1.0,
                   child: InkWell(

--- a/packages/flutter_form_bloc/lib/src/dropdown_field_bloc_builder.dart
+++ b/packages/flutter_form_bloc/lib/src/dropdown_field_bloc_builder.dart
@@ -9,7 +9,7 @@ import 'package:form_bloc/form_bloc.dart';
 
 /// A material design dropdown.
 class DropdownFieldBlocBuilder<Value> extends StatelessWidget {
-  DropdownFieldBlocBuilder({
+  const DropdownFieldBlocBuilder({
     Key? key,
     required this.selectFieldBloc,
     required this.itemBuilder,
@@ -260,7 +260,7 @@ class DropdownFieldBlocBuilder<Value> extends StatelessWidget {
     required bool isEnabled,
   }) {
     final builder =
-        (isSelected ? this.selectedItemBuilder : itemBuilder) ?? itemBuilder;
+        (isSelected ? selectedItemBuilder : itemBuilder) ?? itemBuilder;
 
     return [
       if (showEmptyItem)

--- a/packages/flutter_form_bloc/lib/src/field_bloc_builder.dart
+++ b/packages/flutter_form_bloc/lib/src/field_bloc_builder.dart
@@ -3,13 +3,18 @@ import 'package:form_bloc/form_bloc.dart';
 
 typedef DefaultFieldBlocErrorBuilder = String Function(
   BuildContext context,
-  Object? error,
+  Object error,
   FieldBloc fieldBloc,
 );
 
 class FieldBlocBuilder {
-  static DefaultFieldBlocErrorBuilder defaultErrorBuilder =
-      (BuildContext context, Object? error, FieldBloc fieldBloc) {
+  static DefaultFieldBlocErrorBuilder defaultErrorBuilder = buildDefaultError;
+
+  static String buildDefaultError(
+    BuildContext context,
+    Object error,
+    FieldBloc fieldBloc,
+  ) {
     switch (error) {
       case FieldBlocValidatorsErrors.required:
         if (fieldBloc is MultiSelectFieldBloc || fieldBloc is SelectFieldBloc) {
@@ -25,5 +30,5 @@ class FieldBlocBuilder {
       default:
         return '$error';
     }
-  };
+  }
 }

--- a/packages/flutter_form_bloc/lib/src/flutter_typeahead.dart
+++ b/packages/flutter_form_bloc/lib/src/flutter_typeahead.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: unnecessary_this, prefer_const_constructors, prefer_const_constructors_in_immutables, prefer_generic_function_type_aliases
+
 /*
 BSD 2-Clause License
 

--- a/packages/flutter_form_bloc/lib/src/form_bloc_listener.dart
+++ b/packages/flutter_form_bloc/lib/src/form_bloc_listener.dart
@@ -21,7 +21,7 @@ class FormBlocListener<
   FormBlocListener({
     Key? key,
     this.formBloc,
-    this.child,
+    Widget? child,
     this.onLoading,
     this.onLoaded,
     this.onLoadFailed,
@@ -160,5 +160,6 @@ class FormBlocListener<
   final FormBloc? formBloc;
 
   /// The [Widget] which will be rendered as a descendant of the [BlocListener].
-  final Widget? child;
+  @override
+  Widget? get child => super.child;
 }

--- a/packages/flutter_form_bloc/lib/src/radio_button_group_field_bloc.dart
+++ b/packages/flutter_form_bloc/lib/src/radio_button_group_field_bloc.dart
@@ -141,7 +141,7 @@ class RadioButtonGroupFieldBlocBuilder<Value> extends StatelessWidget {
   ) {
     return ListView.builder(
       shrinkWrap: true,
-      physics: ClampingScrollPhysics(),
+      physics: const ClampingScrollPhysics(),
       itemCount: state.items.length,
       itemBuilder: (context, index) {
         final item = state.items[index];

--- a/packages/flutter_form_bloc/lib/src/stepper/stepper.dart
+++ b/packages/flutter_form_bloc/lib/src/stepper/stepper.dart
@@ -720,15 +720,15 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: <Widget>[
-        Container(
-            height: widget.titleHeight,
-            // Expanded(
-            child: ListView.builder(
-                shrinkWrap: true,
-                scrollDirection: Axis.horizontal,
-                itemCount: children.length,
-                itemBuilder: (BuildContext context, int index) =>
-                    children[index])),
+        SizedBox(
+          height: widget.titleHeight,
+          child: ListView.builder(
+            shrinkWrap: true,
+            scrollDirection: Axis.horizontal,
+            itemCount: children.length,
+            itemBuilder: (BuildContext context, int index) => children[index],
+          ),
+        ),
         Expanded(
           child: ListView(
             physics: widget.physics,

--- a/packages/flutter_form_bloc/lib/src/text_field_bloc_builder.dart
+++ b/packages/flutter_form_bloc/lib/src/text_field_bloc_builder.dart
@@ -146,8 +146,8 @@ class TextFieldBlocBuilder extends StatefulWidget {
       height: 24,
       width: 24,
       child: Padding(
-        padding: const EdgeInsets.all(8.0),
-        child: const CircularProgressIndicator(
+        padding: EdgeInsets.all(8.0),
+        child: CircularProgressIndicator(
           strokeWidth: 2.0,
         ),
       ),
@@ -772,7 +772,7 @@ class _TextFieldBlocBuilderState extends State<TextFieldBlocBuilder> {
       ..selection = TextSelection.collapsed(offset: _controller.text.length);
 
     // TODO: Find out why the cursor returns to the beginning.
-    await Future.delayed(Duration(milliseconds: 0));
+    await Future.delayed(const Duration(milliseconds: 0));
     _controller.selection =
         TextSelection.collapsed(offset: _controller.text.length);
   }
@@ -851,7 +851,7 @@ class _TextFieldBlocBuilderState extends State<TextFieldBlocBuilder> {
         case SuffixButton.asyncValidating:
           decoration = decoration.copyWith(
             suffixIcon: AnimatedOpacity(
-              duration: Duration(milliseconds: 300),
+              duration: const Duration(milliseconds: 300),
               opacity: state.canShowIsValidating ? 1.0 : 0.0,
               child: widget.asyncValidatingIcon,
             ),
@@ -882,11 +882,8 @@ class _TextFieldBlocBuilderState extends State<TextFieldBlocBuilder> {
         autofillHints: widget.autofillHints,
         decoration: _buildDecoration(fieldTheme, state),
         keyboardType: widget.keyboardType,
-        textInputAction: widget.textInputAction != null
-            ? widget.textInputAction
-            : widget.nextFocusNode != null
-                ? TextInputAction.next
-                : null,
+        textInputAction: widget.textInputAction ??
+            (widget.nextFocusNode != null ? TextInputAction.next : null),
         textCapitalization: widget.textCapitalization,
         style: Style.resolveTextStyle(
           isEnabled: isEnabled,
@@ -944,8 +941,8 @@ class _TextFieldBlocBuilderState extends State<TextFieldBlocBuilder> {
               child: Container(
                 height: 36,
                 width: 36,
-                padding: EdgeInsets.all(4.0),
-                child: CircularProgressIndicator(strokeWidth: 3),
+                padding: const EdgeInsets.all(4.0),
+                child: const CircularProgressIndicator(strokeWidth: 3),
               ),
             );
           },

--- a/packages/flutter_form_bloc/lib/src/theme/form_bloc_theme_provider.dart
+++ b/packages/flutter_form_bloc/lib/src/theme/form_bloc_theme_provider.dart
@@ -17,7 +17,7 @@ class FormThemeProvider extends InheritedWidget {
   }
 
   @override
-  bool updateShouldNotify(FormThemeProvider old) {
-    return theme != old.theme;
+  bool updateShouldNotify(FormThemeProvider oldWidget) {
+    return theme != oldWidget.theme;
   }
 }

--- a/packages/flutter_form_bloc/lib/src/utils/field_item.dart
+++ b/packages/flutter_form_bloc/lib/src/utils/field_item.dart
@@ -23,12 +23,14 @@ class FieldItem extends StatelessWidget {
   final Widget child;
 
   const FieldItem({
+    Key? key,
     this.isEnabled = true,
     this.alignment = AlignmentDirectional.centerStart,
     this.onTap,
     required this.child,
-  });
+  }) : super(key: key);
 
+  @override
   Widget build(BuildContext context) {
     return Container(
       constraints: const BoxConstraints(minHeight: kMinInteractiveDimension),

--- a/packages/flutter_form_bloc/lib/src/utils/style.dart
+++ b/packages/flutter_form_bloc/lib/src/utils/style.dart
@@ -26,7 +26,7 @@ class Style {
       } else {
         return FieldBlocBuilder.defaultErrorBuilder(
           context,
-          fieldBlocState.error,
+          fieldBlocState.error!,
           fieldBloc,
         );
       }

--- a/packages/flutter_form_bloc/pubspec.yaml
+++ b/packages/flutter_form_bloc/pubspec.yaml
@@ -19,7 +19,9 @@ dependencies:
   flutter_keyboard_visibility: ^5.0.2
   collection: ^1.15.0
   intl: ^0.17.0
+
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: ^1.11.0
+
+  flutter_lints: ^1.0.4

--- a/packages/form_bloc/analysis_options.yaml
+++ b/packages/form_bloc/analysis_options.yaml
@@ -1,6 +1,14 @@
-include: package:pedantic/analysis_options.yaml
+include: package:lints/recommended.yaml
 
 analyzer:
+  errors:
+    avoid_print: warning
+    annotate_overrides: warning
+    always_use_package_imports: warning
   strong-mode:
     implicit-casts: false
     implicit-dynamic: false
+
+linter:
+  rules:
+    always_use_package_imports: true

--- a/packages/form_bloc/example/analysis_options.yaml
+++ b/packages/form_bloc/example/analysis_options.yaml
@@ -1,6 +1,14 @@
-include: package:pedantic/analysis_options.yaml
+include: package:lints/recommended.yaml
 
 analyzer:
+  errors:
+    avoid_print: warning
+    annotate_overrides: warning
+    always_use_package_imports: warning
   strong-mode:
-    implicit-casts: true
-    implicit-dynamic: true
+    implicit-casts: false
+    implicit-dynamic: false
+
+linter:
+  rules:
+    always_use_package_imports: true

--- a/packages/form_bloc/example/main.dart
+++ b/packages/form_bloc/example/main.dart
@@ -1,14 +1,14 @@
 import 'package:form_bloc/form_bloc.dart';
 
 class LoginFormBloc extends FormBloc<String, String> {
-  final email = TextFieldBloc(
+  final email = TextFieldBloc<dynamic>(
     validators: [
       FieldBlocValidators.required,
       FieldBlocValidators.email,
     ],
   );
 
-  final password = TextFieldBloc(
+  final password = TextFieldBloc<dynamic>(
     validators: [
       FieldBlocValidators.required,
     ],

--- a/packages/form_bloc/example/pubspec.yaml
+++ b/packages/form_bloc/example/pubspec.yaml
@@ -9,3 +9,6 @@ environment:
 dependencies:
   form_bloc:
     path: ../
+
+dev_dependencies:
+  lints: ^1.0.1

--- a/packages/form_bloc/lib/src/blocs/field/field_bloc.dart
+++ b/packages/form_bloc/lib/src/blocs/field/field_bloc.dart
@@ -3,14 +3,12 @@ import 'dart:collection' show LinkedHashSet;
 
 import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
+import 'package:form_bloc/src/blocs/field/field_bloc_utils.dart';
 import 'package:form_bloc/src/blocs/form/form_bloc.dart';
 import 'package:form_bloc/src/utils.dart';
 import 'package:meta/meta.dart';
-import 'package:pedantic/pedantic.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:uuid/uuid.dart';
-
-import 'field_bloc_utils.dart';
 
 part '../boolean_field/boolean_field_bloc.dart';
 part '../boolean_field/boolean_field_state.dart';
@@ -140,7 +138,7 @@ abstract class SingleFieldBloc<
     unawaited(_selectedSuggestionSubject.close());
     unawaited(_asyncValidatorsSubject.close());
     unawaited(_asyncValidatorsSubscription.cancel());
-    unawaited(_revalidateFieldBlocsSubscription?.cancel());
+    _revalidateFieldBlocsSubscription?.cancel();
 
     unawaited(super.close());
   }
@@ -303,7 +301,7 @@ abstract class SingleFieldBloc<
   /// of validator that confirms a password
   /// with the password of other `fieldBloc`.
   void subscribeToFieldBlocs(List<FieldBloc> fieldBlocs) {
-    unawaited(_revalidateFieldBlocsSubscription?.cancel());
+    _revalidateFieldBlocsSubscription?.cancel();
     if (fieldBlocs.isNotEmpty) {
       _revalidateFieldBlocsSubscription = Rx.combineLatest<dynamic, void>(
         fieldBlocs.whereType<SingleFieldBloc>().toList().map(
@@ -311,7 +309,7 @@ abstract class SingleFieldBloc<
             return state.stream.map<dynamic>((state) => state.value).distinct();
           },
         ),
-        (_) => null,
+        (_) {},
       ).listen((_) {
         if (_autoValidate) {
           validate(false);

--- a/packages/form_bloc/lib/src/blocs/form/form_bloc_utils.dart
+++ b/packages/form_bloc/lib/src/blocs/form/form_bloc_utils.dart
@@ -6,42 +6,37 @@ class FormBlocUtils {
   static List<SingleFieldBloc> getAllSingleFieldBlocs(
       Iterable<FieldBloc?> fieldBlocs) {
     final singleFieldBlocs = <SingleFieldBloc>[];
-    fieldBlocs.forEach(
-      (fieldBloc) {
-        if (fieldBloc is SingleFieldBloc) {
-          singleFieldBlocs.add(fieldBloc);
-        } else if (fieldBloc is GroupFieldBloc) {
-          singleFieldBlocs.addAll(
-              getAllSingleFieldBlocs(fieldBloc.state.fieldBlocs.values));
-        } else if (fieldBloc is ListFieldBloc) {
-          singleFieldBlocs.addAll(
-            getAllSingleFieldBlocs(fieldBloc.state.fieldBlocs),
-          );
-        }
-      },
-    );
+    for (var fieldBloc in fieldBlocs) {
+      if (fieldBloc is SingleFieldBloc) {
+        singleFieldBlocs.add(fieldBloc);
+      } else if (fieldBloc is GroupFieldBloc) {
+        singleFieldBlocs
+            .addAll(getAllSingleFieldBlocs(fieldBloc.state.fieldBlocs.values));
+      } else if (fieldBloc is ListFieldBloc) {
+        singleFieldBlocs.addAll(
+          getAllSingleFieldBlocs(fieldBloc.state.fieldBlocs),
+        );
+      }
+    }
 
     return singleFieldBlocs;
   }
 
   static List<FieldBloc> getAllFieldBlocs(Iterable<FieldBloc?> fieldBlocs) {
     final _fieldBlocs = <FieldBloc>[];
-    fieldBlocs.forEach(
-      (fieldBloc) {
-        if (fieldBloc is SingleFieldBloc) {
-          _fieldBlocs.add(fieldBloc);
-        } else if (fieldBloc is GroupFieldBloc) {
-          _fieldBlocs.add(fieldBloc);
-          _fieldBlocs
-              .addAll(getAllFieldBlocs(fieldBloc.state.fieldBlocs.values));
-        } else if (fieldBloc is ListFieldBloc) {
-          _fieldBlocs.add(fieldBloc);
-          _fieldBlocs.addAll(
-            getAllFieldBlocs(fieldBloc.state.fieldBlocs),
-          );
-        }
-      },
-    );
+    for (var fieldBloc in fieldBlocs) {
+      if (fieldBloc is SingleFieldBloc) {
+        _fieldBlocs.add(fieldBloc);
+      } else if (fieldBloc is GroupFieldBloc) {
+        _fieldBlocs.add(fieldBloc);
+        _fieldBlocs.addAll(getAllFieldBlocs(fieldBloc.state.fieldBlocs.values));
+      } else if (fieldBloc is ListFieldBloc) {
+        _fieldBlocs.add(fieldBloc);
+        _fieldBlocs.addAll(
+          getAllFieldBlocs(fieldBloc.state.fieldBlocs),
+        );
+      }
+    }
 
     return _fieldBlocs;
   }
@@ -227,7 +222,7 @@ class FormBlocUtils {
       List<dynamic> fieldBlocsStatesList) {
     final list = <dynamic>[];
 
-    fieldBlocsStatesList.forEach((dynamic fieldBlocState) {
+    for (var fieldBlocState in fieldBlocsStatesList) {
       if (fieldBlocState is FieldBlocState) {
         list.add(fieldBlocState.toJson());
       } else if (fieldBlocState is Map<String, dynamic>) {
@@ -235,7 +230,7 @@ class FormBlocUtils {
       } else if (fieldBlocState is List<dynamic>) {
         list.add(fieldBlocsStatesListToJsonList(fieldBlocState));
       }
-    });
+    }
     return list;
   }
 
@@ -260,7 +255,7 @@ class FormBlocUtils {
       ListFieldBloc fieldBlocList) {
     final list = <dynamic>[];
 
-    fieldBlocList.state.fieldBlocs.forEach((fieldBloc) {
+    for (var fieldBloc in fieldBlocList.state.fieldBlocs) {
       if (fieldBloc is SingleFieldBloc) {
         list.add(fieldBloc.state);
       } else if (fieldBloc is GroupFieldBloc) {
@@ -268,7 +263,7 @@ class FormBlocUtils {
       } else if (fieldBloc is ListFieldBloc) {
         list.add(fieldBlocListToFieldBlocsStatesList(fieldBloc));
       }
-    });
+    }
     return list;
   }
 
@@ -276,7 +271,7 @@ class FormBlocUtils {
       Iterable<dynamic> fieldBlocStateList) {
     final list = <FieldBlocState>[];
 
-    fieldBlocStateList.forEach((dynamic fieldBlocState) {
+    for (var fieldBlocState in fieldBlocStateList) {
       if (fieldBlocState is FieldBlocState) {
         list.add(fieldBlocState);
       } else if (fieldBlocState is Map<String, dynamic>) {
@@ -284,7 +279,7 @@ class FormBlocUtils {
       } else if (fieldBlocState is Iterable) {
         list.addAll(flattenFieldBlocsStateList(fieldBlocState));
       }
-    });
+    }
     return list;
   }
 

--- a/packages/form_bloc/lib/src/blocs/form_bloc_observer.dart
+++ b/packages/form_bloc/lib/src/blocs/form_bloc_observer.dart
@@ -1,7 +1,6 @@
 import 'package:bloc/bloc.dart';
-
-import 'field/field_bloc.dart';
-import 'form/form_bloc.dart';
+import 'package:form_bloc/src/blocs/field/field_bloc.dart';
+import 'package:form_bloc/src/blocs/form/form_bloc.dart';
 
 /// [BlocDelegate] that override the [BlocSupervisor.delegate]
 /// for hide `events` and `transitions`
@@ -74,20 +73,20 @@ class FormBlocObserver extends BlocObserver {
   }
 
   @override
-  void onChange(BlocBase cubit, Change change) {
+  void onChange(BlocBase bloc, Change change) {
     var notify = true;
 
-    if ((cubit is SingleFieldBloc ||
-            cubit is GroupFieldBloc ||
-            cubit is ListFieldBloc) &&
+    if ((bloc is SingleFieldBloc ||
+            bloc is GroupFieldBloc ||
+            bloc is ListFieldBloc) &&
         !notifyOnFieldBlocTransition) {
       notify = false;
-    } else if (cubit is FormBloc && !notifyOnFormBlocTransition) {
+    } else if (bloc is FormBloc && !notifyOnFormBlocTransition) {
       notify = false;
     }
 
     if (notify) {
-      super.onChange(cubit, change);
+      super.onChange(bloc, change);
     }
   }
 
@@ -110,20 +109,20 @@ class FormBlocObserver extends BlocObserver {
   }
 
   @override
-  void onError(BlocBase cubit, Object error, StackTrace stacktrace) {
+  void onError(BlocBase bloc, Object error, StackTrace stackTrace) {
     var notify = true;
 
-    if ((cubit is SingleFieldBloc ||
-            cubit is GroupFieldBloc ||
-            cubit is ListFieldBloc) &&
+    if ((bloc is SingleFieldBloc ||
+            bloc is GroupFieldBloc ||
+            bloc is ListFieldBloc) &&
         !notifyOnFieldBlocError) {
       notify = false;
-    } else if (cubit is FormBloc && !notifyOnFormBlocError) {
+    } else if (bloc is FormBloc && !notifyOnFormBlocError) {
       notify = false;
     }
 
     if (notify) {
-      super.onError(cubit, error, stacktrace);
+      super.onError(bloc, error, stackTrace);
     }
   }
 }

--- a/packages/form_bloc/lib/src/validators/field_bloc_validators.dart
+++ b/packages/form_bloc/lib/src/validators/field_bloc_validators.dart
@@ -1,4 +1,4 @@
-import '../blocs/field/field_bloc.dart';
+import 'package:form_bloc/src/blocs/field/field_bloc.dart';
 
 class FieldBlocValidatorsErrors {
   FieldBlocValidatorsErrors._();

--- a/packages/form_bloc/pubspec.yaml
+++ b/packages/form_bloc/pubspec.yaml
@@ -4,18 +4,21 @@ version: 0.29.0
 homepage: 'https://github.com/GiancarloCode/form_bloc/tree/master/packages/form_bloc'
 repository: 'https://github.com/GiancarloCode/form_bloc/tree/master/packages/form_bloc'
 issue_tracker: 'https://github.com/GiancarloCode/form_bloc/issues'
+
 environment:
   sdk: '>=2.14.0 <3.0.0'
+
 dependencies:
   meta: ^1.7.0
   bloc: ^8.0.1
   rxdart: ^0.27.3
   equatable: ^2.0.3
-  pedantic: ^1.11.1
   collection: ^1.15.0
   uuid: ^3.0.4
+
 dev_dependencies:
   test: ^1.16.8
   mockito: ^5.0.16
   bloc_test: ^9.0.1
 
+  lints: ^1.0.1

--- a/packages/form_bloc/test/boolean_field/boolean_field_bloc_test.dart
+++ b/packages/form_bloc/test/boolean_field/boolean_field_bloc_test.dart
@@ -6,7 +6,7 @@ void main() {
   group('BooleanFieldBloc:', () {
     group('constructor:', () {
       test('call the super constructor correctly.', () {
-        final suggestions = (String pattern) async => [true];
+        Future<List<bool>> suggestions(String pattern) async => [true];
         final validators = [(bool? value) => value! ? 'error' : null];
 
         final fieldBloc = BooleanFieldBloc<dynamic>(

--- a/packages/form_bloc/test/boolean_field/boolean_field_state_test.dart
+++ b/packages/form_bloc/test/boolean_field/boolean_field_state_test.dart
@@ -5,7 +5,7 @@ import 'package:test/test.dart';
 void main() {
   group('BooleanFieldBlocState:', () {
     test('copyWith.', () {
-      final suggestions = (String pattern) async => [true];
+      Future<List<bool>> suggestions(String pattern) async => [true];
 
       final state = BooleanFieldBlocState<dynamic>(
         value: false,

--- a/packages/form_bloc/test/field_bloc/field_bloc_test.dart
+++ b/packages/form_bloc/test/field_bloc/field_bloc_test.dart
@@ -166,7 +166,7 @@ void main() {
 
       test('_suggestions is added to suggestions of the current state.',
           () async {
-        final suggestions = (String pattern) async => [1, 2, 3];
+        Future<List<int>> suggestions(String pattern) async => [1, 2, 3];
         final fieldBloc = InputFieldBloc<int?, dynamic>(
           name: 'fieldName',
           initialValue: null,
@@ -745,8 +745,8 @@ void main() {
     });
 
     test('updateSuggestions method and UpdateSuggestions event.', () {
-      final suggestions1 = (String pattern) async => [1];
-      final suggestions2 = (String pattern) async => [2];
+      Future<List<int>> suggestions1(String pattern) async => [1];
+      Future<List<int>> suggestions2(String pattern) async => [2];
 
       final fieldBloc = InputFieldBloc<int?, dynamic>(
         name: 'fieldName',

--- a/packages/form_bloc/test/input_field/input_field_bloc_test.dart
+++ b/packages/form_bloc/test/input_field/input_field_bloc_test.dart
@@ -6,7 +6,7 @@ void main() {
   group('InputFieldBloc:', () {
     group('constructor:', () {
       test('call the super constructor correctly.', () {
-        final suggestions = (String pattern) async => [true];
+        Future<List<bool>> suggestions(String pattern) async => [true];
         final validators = [
           FieldBlocValidators.required,
           (bool? value) => value! ? 'error' : null,

--- a/packages/form_bloc/test/input_field/input_field_state_test.dart
+++ b/packages/form_bloc/test/input_field/input_field_state_test.dart
@@ -5,7 +5,7 @@ import 'package:test/test.dart';
 void main() {
   group('InputFieldBlocState:', () {
     test('copyWith.', () {
-      final suggestions = (String pattern) async => [1];
+      Future<List<int>> suggestions(String pattern) async => [1];
 
       final state = InputFieldBlocState<int?, dynamic>(
         value: null,

--- a/packages/form_bloc/test/multi_select_field/multi_select_field_bloc_test.dart
+++ b/packages/form_bloc/test/multi_select_field/multi_select_field_bloc_test.dart
@@ -6,7 +6,7 @@ void main() {
   group('MultiSelectFieldBloc:', () {
     group('constructor:', () {
       test('call the super constructor correctly.', () {
-        final suggestions = (String pattern) async => [true];
+        Future<List<bool>> suggestions(String pattern) async => [true];
         final validators = [
           FieldBlocValidators.required,
           (List<bool>? value) => 'error',

--- a/packages/form_bloc/test/multi_select_field/multi_select_field_state_test.dart
+++ b/packages/form_bloc/test/multi_select_field/multi_select_field_state_test.dart
@@ -5,7 +5,7 @@ import 'package:test/test.dart';
 void main() {
   group('MultiSelectFieldBlocState:', () {
     test('copyWith.', () {
-      final suggestions = (String pattern) async => [1];
+      Future<List<int>> suggestions(String pattern) async => [1];
 
       final state = MultiSelectFieldBlocState<int?, dynamic>(
         value: [],

--- a/packages/form_bloc/test/select_field/select_field_bloc_test.dart
+++ b/packages/form_bloc/test/select_field/select_field_bloc_test.dart
@@ -6,7 +6,7 @@ void main() {
   group('SelectFieldBloc:', () {
     group('constructor:', () {
       test('call the super constructor correctly.', () {
-        final suggestions = (String pattern) async => [true];
+        Future<List<bool>> suggestions(String pattern) async => [true];
         final validators = [
           FieldBlocValidators.required,
           (bool? value) => value ?? false ? 'error' : null,

--- a/packages/form_bloc/test/select_field/select_field_state_test.dart
+++ b/packages/form_bloc/test/select_field/select_field_state_test.dart
@@ -5,7 +5,7 @@ import 'package:test/test.dart';
 void main() {
   group('SelectFieldBlocState:', () {
     test('copyWith.', () {
-      final suggestions = (String pattern) async => [1];
+      Future<List<int>> suggestions(String pattern) async => [1];
 
       final state = SelectFieldBlocState<int?, dynamic>(
         value: null,

--- a/packages/form_bloc/test/text_field/text_field_bloc_test.dart
+++ b/packages/form_bloc/test/text_field/text_field_bloc_test.dart
@@ -6,7 +6,7 @@ void main() {
   group('TextFieldBloc:', () {
     group('constructor:', () {
       test('call the super constructor correctly.', () {
-        final suggestions = (String pattern) async => ['1'];
+        Future<List<String>> suggestions(String pattern) async => ['1'];
         final validators = [
           FieldBlocValidators.required,
           (String? value) => 'error',

--- a/packages/form_bloc/test/text_field/text_field_state_test.dart
+++ b/packages/form_bloc/test/text_field/text_field_state_test.dart
@@ -5,7 +5,7 @@ import 'package:test/test.dart';
 void main() {
   group('TextFieldBlocState:', () {
     test('copyWith.', () {
-      final suggestions = (String pattern) async => ['1'];
+      Future<List<String>> suggestions(String pattern) async => ['1'];
 
       final state = TextFieldBlocState<dynamic>(
         value: '',


### PR DESCRIPTION
I added these rules to avoid
- wrong imports
- indiserated print
- the lack of the `@ override` annotation

```yaml
analyzer:
  errors:
    avoid_print: warning
    annotate_overrides: warning
    always_use_package_imports: warning

linter:
  rules:
    always_use_package_imports: true
```

The dependency of `pendatic` has been removed as it is no longer supported