### PR TITLE
Improve FieldBloc.value management

### DIFF
--- a/packages/flutter_form_bloc/lib/src/checkbox_field_bloc_builder.dart
+++ b/packages/flutter_form_bloc/lib/src/checkbox_field_bloc_builder.dart
@@ -189,7 +189,7 @@ class CheckboxFieldBlocBuilder extends StatelessWidget {
       onChanged: fieldBlocBuilderOnChange<bool?>(
         isEnabled: isEnabled,
         nextFocusNode: nextFocusNode,
-        onChanged: booleanFieldBloc.updateValue as void Function(bool?),
+        onChanged: booleanFieldBloc.changeValue as void Function(bool?),
       ),
     );
   }

--- a/packages/flutter_form_bloc/lib/src/chip/choice_chip_field_bloc_builder.dart
+++ b/packages/flutter_form_bloc/lib/src/chip/choice_chip_field_bloc_builder.dart
@@ -234,11 +234,7 @@ class ChoiceChipFieldBlocBuilder<T> extends StatelessWidget {
                         readOnly: readOnly,
                         nextFocusNode: nextFocusNode,
                         onChanged: (isSelected) {
-                          if (isSelected) {
-                            selectFieldBloc.updateValue(item);
-                          } else if (canDeselect) {
-                            selectFieldBloc.updateValue(null);
-                          }
+                          selectFieldBloc.changeValue(isSelected ? item : null);
                           fieldItem.onTap?.call();
                         },
                       ),

--- a/packages/flutter_form_bloc/lib/src/date_time/date_time_field_bloc_builder_base.dart
+++ b/packages/flutter_form_bloc/lib/src/date_time/date_time_field_bloc_builder_base.dart
@@ -182,7 +182,7 @@ class _DateTimeFieldBlocBuilderBaseState<T>
         isEnabled: widget.isEnabled,
         nextFocusNode: widget.nextFocusNode,
         onChanged: (value) {
-          widget.dateTimeFieldBloc.updateValue(value);
+          widget.dateTimeFieldBloc.changeValue(value);
           // Used for hide keyboard
           // FocusScope.of(context).requestFocus(FocusNode());
         },

--- a/packages/flutter_form_bloc/lib/src/dropdown_field_bloc_builder.dart
+++ b/packages/flutter_form_bloc/lib/src/dropdown_field_bloc_builder.dart
@@ -202,7 +202,7 @@ class DropdownFieldBlocBuilder<Value> extends StatelessWidget {
                       isEnabled: isEnabled,
                       nextFocusNode: nextFocusNode,
                       onChanged: (value) {
-                        selectFieldBloc.updateValue(value);
+                        selectFieldBloc.changeValue(value);
                         onChanged?.call(value);
                       },
                     ),

--- a/packages/flutter_form_bloc/lib/src/groups/fields/radio_button_group_field_bloc.dart
+++ b/packages/flutter_form_bloc/lib/src/groups/fields/radio_button_group_field_bloc.dart
@@ -170,7 +170,7 @@ class RadioButtonGroupFieldBlocBuilder<Value> extends StatelessWidget {
             isEnabled: isEnabled,
             nextFocusNode: nextFocusNode,
             onChanged: (value) {
-              selectFieldBloc.updateValue(value);
+              selectFieldBloc.changeValue(value);
               fieldItem.onTap?.call();
             },
           );

--- a/packages/flutter_form_bloc/lib/src/slider/slider_field_bloc_builder.dart
+++ b/packages/flutter_form_bloc/lib/src/slider/slider_field_bloc_builder.dart
@@ -127,7 +127,7 @@ class SliderFieldBlocBuilder extends StatelessWidget {
                       isEnabled: isEnabled,
                       readOnly: readOnly,
                       nextFocusNode: nextFocusNode,
-                      onChanged: inputFieldBloc.updateValue,
+                      onChanged: inputFieldBloc.changeValue,
                     ),
                     label: labelBuilder?.call(context, value),
                     activeColor: activeColor,

--- a/packages/flutter_form_bloc/lib/src/switch_field_bloc_builder.dart
+++ b/packages/flutter_form_bloc/lib/src/switch_field_bloc_builder.dart
@@ -201,7 +201,7 @@ class SwitchFieldBlocBuilder extends StatelessWidget {
       onChanged: fieldBlocBuilderOnChange<bool>(
         isEnabled: isEnabled,
         nextFocusNode: nextFocusNode,
-        onChanged: booleanFieldBloc.updateValue,
+        onChanged: booleanFieldBloc.changeValue,
       ),
       activeThumbImage: activeThumbImage,
       autofocus: autofocus,

--- a/packages/flutter_form_bloc/lib/src/text_field_bloc_builder.dart
+++ b/packages/flutter_form_bloc/lib/src/text_field_bloc_builder.dart
@@ -931,7 +931,7 @@ class _TextFieldBlocBuilderState extends State<TextFieldBlocBuilder> {
         maxLength: widget.maxLength,
         maxLengthEnforcement: widget.maxLengthEnforced,
         onChanged: (value) {
-          widget.textFieldBloc.updateValue(value);
+          widget.textFieldBloc.changeValue(value);
           if (widget.onChanged != null) {
             widget.onChanged!(value);
           }
@@ -1012,7 +1012,7 @@ class _TextFieldBlocBuilderState extends State<TextFieldBlocBuilder> {
         );
       },
       onSuggestionSelected: (value) {
-        widget.textFieldBloc.updateValue(value);
+        widget.textFieldBloc.changeValue(value);
         _onSubmitted(value);
       },
       animationDuration: widget.suggestionsAnimationDuration,

--- a/packages/flutter_form_bloc/pubspec.yaml
+++ b/packages/flutter_form_bloc/pubspec.yaml
@@ -13,9 +13,9 @@ dependencies:
     sdk: flutter
 
   flutter_bloc: ^8.0.0
-#  form_bloc:
-#    path: ../form_bloc
-  form_bloc: ^0.29.1
+  form_bloc:
+    path: ../form_bloc
+#  form_bloc: ^0.29.1
   equatable: ^2.0.3
   rxdart: ^0.27.3
   flutter_keyboard_visibility: ^5.0.2

--- a/packages/form_bloc/lib/src/blocs/boolean_field/boolean_field_bloc.dart
+++ b/packages/form_bloc/lib/src/blocs/boolean_field/boolean_field_bloc.dart
@@ -43,21 +43,19 @@ class BooleanFieldBloc<ExtraData> extends SingleFieldBloc<bool, bool,
     Suggestions<bool>? suggestions,
     ExtraData? extraData,
   }) : super(
-          initialValue,
-          validators,
-          asyncValidators,
-          asyncValidatorDebounceTime,
-          suggestions,
-          name,
-          (value) => value,
-          extraData,
-          BooleanFieldBlocState(
+          validators: validators,
+          asyncValidators: asyncValidators,
+          asyncValidatorDebounceTime: asyncValidatorDebounceTime,
+          initialState: BooleanFieldBlocState(
+            isValueChanged: false,
+            initialValue: initialValue,
+            updatedValue: initialValue,
             value: initialValue,
             error: FieldBlocUtils.getInitialStateError(
               validators: validators,
               value: initialValue,
             ),
-            isInitial: true,
+            isDirty: false,
             suggestions: suggestions,
             isValidated: FieldBlocUtils.getInitialIsValidated(
               FieldBlocUtils.getInitialStateIsValidating(

--- a/packages/form_bloc/lib/src/blocs/boolean_field/boolean_field_state.dart
+++ b/packages/form_bloc/lib/src/blocs/boolean_field/boolean_field_state.dart
@@ -3,9 +3,12 @@ part of '../field/field_bloc.dart';
 class BooleanFieldBlocState<ExtraData>
     extends FieldBlocState<bool, bool, ExtraData?> {
   BooleanFieldBlocState({
+    required bool isValueChanged,
+    required bool initialValue,
+    required bool updatedValue,
     required bool value,
     required Object? error,
-    required bool isInitial,
+    required bool isDirty,
     required Suggestions<bool>? suggestions,
     required bool isValidated,
     required bool isValidating,
@@ -15,9 +18,12 @@ class BooleanFieldBlocState<ExtraData>
     dynamic Function(bool value)? toJson,
     ExtraData? extraData,
   }) : super(
+          isValueChanged: isValueChanged,
+          initialValue: initialValue,
+          updatedValue: updatedValue,
           value: value,
           error: error,
-          isInitial: isInitial,
+          isDirty: isDirty,
           suggestions: suggestions,
           isValidated: isValidated,
           isValidating: isValidating,
@@ -29,9 +35,12 @@ class BooleanFieldBlocState<ExtraData>
 
   @override
   BooleanFieldBlocState<ExtraData> copyWith({
+    bool? isValueChanged,
+    Param<bool>? initialValue,
+    Param<bool>? updatedValue,
     Param<bool>? value,
     Param<Object?>? error,
-    bool? isInitial,
+    bool? isDirty,
     Param<Suggestions<bool>?>? suggestions,
     bool? isValidated,
     bool? isValidating,
@@ -39,10 +48,13 @@ class BooleanFieldBlocState<ExtraData>
     Param<ExtraData?>? extraData,
   }) {
     return BooleanFieldBlocState(
+      isValueChanged: isValueChanged ?? this.isValueChanged,
+      initialValue: initialValue.or(this.initialValue),
+      updatedValue: updatedValue.or(this.updatedValue),
       value: value == null ? this.value : value.value,
       error: error == null ? this.error : error.value,
-      isInitial: isInitial ?? this.isInitial,
       suggestions: suggestions == null ? this.suggestions : suggestions.value,
+      isDirty: isDirty ?? this.isDirty,
       isValidated: isValidated ?? this.isValidated,
       isValidating: isValidating ?? this.isValidating,
       formBloc: formBloc == null ? this.formBloc : formBloc.value,
@@ -51,16 +63,4 @@ class BooleanFieldBlocState<ExtraData>
       extraData: extraData == null ? this.extraData : extraData.value,
     );
   }
-
-  @override
-  List<Object?> get props => [
-        value,
-        error,
-        isInitial,
-        suggestions,
-        isValidated,
-        isValidating,
-        extraData,
-        formBloc,
-      ];
 }

--- a/packages/form_bloc/lib/src/blocs/field/field_bloc_utils.dart
+++ b/packages/form_bloc/lib/src/blocs/field/field_bloc_utils.dart
@@ -1,3 +1,6 @@
+import 'dart:collection';
+
+import 'package:collection/collection.dart';
 import 'package:form_bloc/src/blocs/field/field_bloc.dart';
 import 'package:uuid/uuid.dart';
 
@@ -60,4 +63,38 @@ class ValueAndError<Value> {
   final Object? error;
 
   ValueAndError(this.value, this.error);
+}
+
+class EquatableList<T> with ListMixin<T> {
+  static final _equality = const ListEquality<dynamic>();
+
+  final List<T> _internal;
+
+  EquatableList._(this._internal);
+
+  factory EquatableList(List<T> list) {
+    return list is EquatableList<T> ? list : EquatableList._(list);
+  }
+
+  @override
+  int get length => _internal.length;
+  @override
+  set length(int newLength) => _internal.length = newLength;
+
+  @override
+  T operator [](int index) => _internal[index];
+
+  @override
+  void operator []=(int index, T value) {
+    _internal[index] = value;
+  }
+
+  @override
+  int get hashCode => _equality.hash(this);
+
+  @override
+  bool operator ==(Object other) {
+    if (other is! List<T>) return false;
+    return _equality.equals(this, other);
+  }
 }

--- a/packages/form_bloc/lib/src/blocs/form/form_bloc.dart
+++ b/packages/form_bloc/lib/src/blocs/form/form_bloc.dart
@@ -291,6 +291,28 @@ abstract class FormBloc<SuccessResponse, FailureResponse>
   }
 
   // ===========================================================================
+  // UTILITY
+  // ===========================================================================
+
+  /// {@template form_bloc.isValuesChanged}
+  /// Check if all field blocs and their children have undergone a change in values
+  /// {@endtemplate}
+  bool isValuesChanged({int? step}) =>
+      FormBlocUtils.isValuesChanged(state.flatFieldBlocs(step) ?? const []);
+
+  /// {@template form_bloc.hasInitialValues}
+  /// Check if all field blocs and their children have initial values
+  /// {@endtemplate}
+  bool hasInitialValues({int? step}) =>
+      FormBlocUtils.hasInitialValues(state.flatFieldBlocs(step) ?? const []);
+
+  /// {@template form_bloc.hasUpdatedValues}
+  /// Check if all field blocs and their children have updated values
+  /// {@endtemplate}
+  bool hasUpdatedValues({int? step}) =>
+      FormBlocUtils.hasUpdatedValues(state.flatFieldBlocs(step) ?? const []);
+
+  // ===========================================================================
   // toString
   // ===========================================================================
   @override
@@ -316,19 +338,9 @@ abstract class FormBloc<SuccessResponse, FailureResponse>
         currentStep: state.currentStep,
       ));
       emit(state.toLoaded()._copyWith(currentStep: notValidStep));
-    } else if (_autoValidate) {
-      // Auto validate is enabled, not required validate all field blocs
-
-      if (!state.isValid(state.currentStep)) {
-        emit(FormBlocSubmissionFailed(
-          isValidByStep: state._isValidByStep,
-          isEditing: state.isEditing,
-          fieldBlocs: state._fieldBlocs,
-          currentStep: state.currentStep,
-        ));
-        emit(state.toLoaded());
-        return;
-      }
+    } else if (_autoValidate && state.isValid(state.currentStep)) {
+      // Auto validate is enabled, required validate all field blocs
+      // if step isn't valid to show a error (if value is initial)
 
       emit(state.toSubmitting());
 

--- a/packages/form_bloc/lib/src/blocs/form/form_bloc_utils.dart
+++ b/packages/form_bloc/lib/src/blocs/form/form_bloc_utils.dart
@@ -374,4 +374,49 @@ class FormBlocUtils {
       fieldBloc.removeFormBloc(formBloc);
     }
   }
+
+  /// See [FormBloc.isValuesChanged]
+  static bool isValuesChanged(
+    Iterable<FieldBloc> fieldBlocs, {
+    bool fallback = false,
+  }) {
+    return fieldBlocs.any((fb) {
+      if (fb is SingleFieldBloc) {
+        return fb.isValueChanged;
+      } else if (fb is MultiFieldBloc) {
+        return fb.isValuesChanged;
+      }
+      return fallback;
+    });
+  }
+
+  /// See [FormBloc.hasInitialValues]
+  static bool hasInitialValues(
+    Iterable<FieldBloc> fieldBlocs, {
+    bool fallback = true,
+  }) {
+    return fieldBlocs.every((fb) {
+      if (fb is SingleFieldBloc) {
+        return fb.hasInitialValue;
+      } else if (fb is MultiFieldBloc) {
+        return fb.hasInitialValues;
+      }
+      return fallback;
+    });
+  }
+
+  /// See [FormBloc.hasUpdatedValues]
+  static bool hasUpdatedValues(
+    Iterable<FieldBloc> fieldBlocs, {
+    bool fallback = true,
+  }) {
+    return fieldBlocs.every((fb) {
+      if (fb is SingleFieldBloc) {
+        return fb.hasUpdatedValue;
+      } else if (fb is MultiFieldBloc) {
+        return fb.hasUpdatedValues;
+      }
+      return fallback;
+    });
+  }
 }

--- a/packages/form_bloc/lib/src/blocs/form/form_state.dart
+++ b/packages/form_bloc/lib/src/blocs/form/form_state.dart
@@ -26,19 +26,10 @@ abstract class FormBlocState<SuccessResponse, FailureResponse>
     }
   }
 
+  @Deprecated(
+      'In favour of [FormBloc.hasInitialValues] or [FormBloc.isValuesChanged].')
   bool isInitial([int? step]) {
-    if (step == null) {
-      return FormBlocUtils.flattenFieldBlocsStateList(_fieldBlocsStates.values)
-          .every((state) => state.isInitial);
-    }
-
-    if (!_fieldBlocsStatesByStepMap.containsKey(step)) {
-      return false;
-    }
-
-    return FormBlocUtils.flattenFieldBlocsStateList(
-            _fieldBlocsStatesByStepMap[step]!.values)
-        .every((state) => state.isInitial);
+    return FormBlocUtils.hasInitialValues(flatFieldBlocs(step) ?? const []);
   }
 
   /// It is usually used in forms that are used as CRUD,

--- a/packages/form_bloc/lib/src/blocs/input_field/input_field_bloc.dart
+++ b/packages/form_bloc/lib/src/blocs/input_field/input_field_bloc.dart
@@ -46,21 +46,19 @@ class InputFieldBloc<Value, ExtraData> extends SingleFieldBloc<Value, Value,
     dynamic Function(Value value)? toJson,
     ExtraData? extraData,
   }) : super(
-          initialValue,
-          validators,
-          asyncValidators,
-          asyncValidatorDebounceTime,
-          suggestions,
-          name,
-          toJson,
-          extraData,
-          InputFieldBlocState(
+          validators: validators,
+          asyncValidators: asyncValidators,
+          asyncValidatorDebounceTime: asyncValidatorDebounceTime,
+          initialState: InputFieldBlocState(
+            isValueChanged: false,
+            initialValue: initialValue,
+            updatedValue: initialValue,
             value: initialValue,
             error: FieldBlocUtils.getInitialStateError(
               validators: validators,
               value: initialValue,
             ),
-            isInitial: true,
+            isDirty: false,
             suggestions: suggestions,
             isValidated: FieldBlocUtils.getInitialIsValidated(
               FieldBlocUtils.getInitialStateIsValidating(

--- a/packages/form_bloc/lib/src/blocs/input_field/input_field_state.dart
+++ b/packages/form_bloc/lib/src/blocs/input_field/input_field_state.dart
@@ -3,9 +3,12 @@ part of '../field/field_bloc.dart';
 class InputFieldBlocState<Value, ExtraData>
     extends FieldBlocState<Value, Value, ExtraData?> {
   InputFieldBlocState({
+    required bool isValueChanged,
+    required Value initialValue,
+    required Value updatedValue,
     required Value value,
     required Object? error,
-    required bool isInitial,
+    required bool isDirty,
     required Suggestions<Value>? suggestions,
     required bool isValidated,
     required bool isValidating,
@@ -15,9 +18,12 @@ class InputFieldBlocState<Value, ExtraData>
     dynamic Function(Value value)? toJson,
     ExtraData? extraData,
   }) : super(
+          isValueChanged: isValueChanged,
+          initialValue: initialValue,
+          updatedValue: updatedValue,
           value: value,
           error: error,
-          isInitial: isInitial,
+          isDirty: isDirty,
           suggestions: suggestions,
           isValidated: isValidated,
           isValidating: isValidating,
@@ -29,9 +35,12 @@ class InputFieldBlocState<Value, ExtraData>
 
   @override
   InputFieldBlocState<Value, ExtraData> copyWith({
+    bool? isValueChanged,
+    Param<Value>? initialValue,
+    Param<Value>? updatedValue,
     Param<Value>? value,
     Param<Object?>? error,
-    bool? isInitial,
+    bool? isDirty,
     Param<Suggestions<Value>?>? suggestions,
     bool? isValidated,
     bool? isValidating,
@@ -39,9 +48,12 @@ class InputFieldBlocState<Value, ExtraData>
     Param<ExtraData?>? extraData,
   }) {
     return InputFieldBlocState(
+      isValueChanged: isValueChanged ?? this.isValueChanged,
+      initialValue: initialValue.or(this.initialValue),
+      updatedValue: updatedValue.or(this.updatedValue),
       value: value == null ? this.value : value.value,
       error: error == null ? this.error : error.value,
-      isInitial: isInitial ?? this.isInitial,
+      isDirty: isDirty ?? this.isDirty,
       suggestions: suggestions == null ? this.suggestions : suggestions.value,
       isValidated: isValidated ?? this.isValidated,
       isValidating: isValidating ?? this.isValidating,
@@ -51,16 +63,4 @@ class InputFieldBlocState<Value, ExtraData>
       extraData: extraData == null ? this.extraData : extraData.value,
     );
   }
-
-  @override
-  List<Object?> get props => [
-        value,
-        error,
-        isInitial,
-        suggestions,
-        isValidated,
-        isValidating,
-        extraData,
-        formBloc,
-      ];
 }

--- a/packages/form_bloc/lib/src/blocs/multi_select_field/multi_select_field_bloc.dart
+++ b/packages/form_bloc/lib/src/blocs/multi_select_field/multi_select_field_bloc.dart
@@ -40,7 +40,7 @@ class MultiSelectFieldBloc<Value, ExtraData> extends SingleFieldBloc<
   /// * [items] : The list of items that can be selected to update the value.
   /// * [toJson] Transform [value] in a JSON value.
   /// By default returns [value].
-  /// This method is called when you use [FormBlocState.toJson]
+  /// This method is called when you use [FormBlocState.toJson]…
   /// * [extraData] : It is an object that you can use to add extra data, it will be available in the state [FieldBlocState.extraData].
   MultiSelectFieldBloc({
     String? name,
@@ -53,21 +53,20 @@ class MultiSelectFieldBloc<Value, ExtraData> extends SingleFieldBloc<
     dynamic Function(List<Value> value)? toJson,
     ExtraData? extraData,
   }) : super(
-          initialValue,
-          validators,
-          asyncValidators,
-          asyncValidatorDebounceTime,
-          suggestions,
-          name,
-          toJson,
-          extraData,
-          MultiSelectFieldBlocState(
+          equality: const ListEquality<Never>(),
+          validators: validators,
+          asyncValidators: asyncValidators,
+          asyncValidatorDebounceTime: asyncValidatorDebounceTime,
+          initialState: MultiSelectFieldBlocState(
+            isValueChanged: false,
+            initialValue: initialValue,
+            updatedValue: initialValue,
             value: initialValue,
             error: FieldBlocUtils.getInitialStateError(
               validators: validators,
               value: initialValue,
             ),
-            isInitial: true,
+            isDirty: false,
             suggestions: suggestions,
             isValidated: FieldBlocUtils.getInitialIsValidated(
               FieldBlocUtils.getInitialStateIsValidating(
@@ -162,15 +161,14 @@ class MultiSelectFieldBloc<Value, ExtraData> extends SingleFieldBloc<
     newValue =
         SingleFieldBloc._itemsWithoutDuplicates([...newValue, valueToSelect]);
     if (_canUpdateValue(value: newValue, isInitialValue: false)) {
-      final error = _getError(newValue);
-
+      final error = _getError(value: newValue);
       final isValidating =
           _getAsyncValidatorsError(value: newValue, error: error);
 
       emit(state.copyWith(
+        isValueChanged: true,
         value: Param(newValue),
         error: Param(error),
-        isInitial: false,
         isValidated: _isValidated(isValidating),
         isValidating: isValidating,
       ));
@@ -186,15 +184,15 @@ class MultiSelectFieldBloc<Value, ExtraData> extends SingleFieldBloc<
     var newValue = state.value;
     newValue = [...newValue]..remove(valueToDeselect);
     if (_canUpdateValue(value: newValue, isInitialValue: false)) {
-      final error = _getError(newValue);
+      final error = _getError(value: newValue);
 
       final isValidating =
           _getAsyncValidatorsError(value: newValue, error: error);
 
       emit(state.copyWith(
+        isValueChanged: true,
         value: Param(newValue),
         error: Param(error),
-        isInitial: false,
         isValidated: _isValidated(isValidating),
         isValidating: isValidating,
       ));

--- a/packages/form_bloc/lib/src/blocs/multi_select_field/multi_select_field_state.dart
+++ b/packages/form_bloc/lib/src/blocs/multi_select_field/multi_select_field_state.dart
@@ -5,9 +5,12 @@ class MultiSelectFieldBlocState<Value, ExtraData>
   final List<Value> items;
 
   MultiSelectFieldBlocState({
+    required bool isValueChanged,
+    required List<Value> initialValue,
+    required List<Value> updatedValue,
     required List<Value> value,
     required Object? error,
-    required bool isInitial,
+    required bool isDirty,
     required Suggestions<Value>? suggestions,
     required bool isValidated,
     required bool isValidating,
@@ -17,9 +20,12 @@ class MultiSelectFieldBlocState<Value, ExtraData>
     dynamic Function(List<Value> value)? toJson,
     ExtraData? extraData,
   }) : super(
-          value: value,
+          isValueChanged: isValueChanged,
+          initialValue: EquatableList(initialValue),
+          updatedValue: EquatableList(updatedValue),
+          value: EquatableList(value),
           error: error,
-          isInitial: isInitial,
+          isDirty: isDirty,
           suggestions: suggestions,
           isValidated: isValidated,
           isValidating: isValidating,
@@ -31,9 +37,12 @@ class MultiSelectFieldBlocState<Value, ExtraData>
 
   @override
   MultiSelectFieldBlocState<Value, ExtraData> copyWith({
+    bool? isValueChanged,
+    Param<List<Value>>? initialValue,
+    Param<List<Value>>? updatedValue,
     Param<List<Value>>? value,
     Param<Object?>? error,
-    bool? isInitial,
+    bool? isDirty,
     Param<Suggestions<Value>?>? suggestions,
     bool? isValidated,
     bool? isValidating,
@@ -42,9 +51,12 @@ class MultiSelectFieldBlocState<Value, ExtraData>
     Param<ExtraData?>? extraData,
   }) {
     return MultiSelectFieldBlocState(
+      isValueChanged: isValueChanged ?? this.isValueChanged,
+      initialValue: initialValue.or(this.initialValue),
+      updatedValue: updatedValue.or(this.updatedValue),
       value: value == null ? this.value : value.value,
       error: error == null ? this.error : error.value,
-      isInitial: isInitial ?? this.isInitial,
+      isDirty: isDirty ?? this.isDirty,
       suggestions: suggestions == null ? this.suggestions : suggestions.value,
       isValidated: isValidated ?? this.isValidated,
       isValidating: isValidating ?? this.isValidating,
@@ -57,18 +69,9 @@ class MultiSelectFieldBlocState<Value, ExtraData>
   }
 
   @override
-  String toString() => _toStringWith(',\n  items: $items');
+  String toString([String extra = '']) =>
+      super.toString(',\n  items: $items$extra');
 
   @override
-  List<Object?> get props => [
-        value,
-        error,
-        isInitial,
-        suggestions,
-        isValidated,
-        isValidating,
-        extraData,
-        formBloc,
-        items,
-      ];
+  List<Object?> get props => [super.props, items];
 }

--- a/packages/form_bloc/lib/src/blocs/select_field/select_field_bloc.dart
+++ b/packages/form_bloc/lib/src/blocs/select_field/select_field_bloc.dart
@@ -49,21 +49,19 @@ class SelectFieldBloc<Value, ExtraData> extends SingleFieldBloc<Value?, Value,
     dynamic Function(Value? value)? toJson,
     ExtraData? extraData,
   }) : super(
-          initialValue,
-          validators,
-          asyncValidators,
-          asyncValidatorDebounceTime,
-          suggestions,
-          name,
-          toJson,
-          extraData,
-          SelectFieldBlocState(
+          validators: validators,
+          asyncValidators: asyncValidators,
+          asyncValidatorDebounceTime: asyncValidatorDebounceTime,
+          initialState: SelectFieldBlocState(
+            isValueChanged: false,
+            initialValue: initialValue,
+            updatedValue: initialValue,
             value: initialValue,
             error: FieldBlocUtils.getInitialStateError(
               validators: validators,
               value: initialValue,
             ),
-            isInitial: true,
+            isDirty: false,
             suggestions: suggestions,
             isValidated: FieldBlocUtils.getInitialIsValidated(
               FieldBlocUtils.getInitialStateIsValidating(
@@ -102,9 +100,7 @@ class SelectFieldBloc<Value, ExtraData> extends SingleFieldBloc<Value?, Value,
   /// of the current state.
   void addItem(Value item) {
     emit(state.copyWith(
-      items: SingleFieldBloc._itemsWithoutDuplicates(
-        List<Value>.from(state.items)..add(item),
-      ),
+      items: SingleFieldBloc._itemsWithoutDuplicates([...state.items, item]),
     ));
   }
 
@@ -113,8 +109,7 @@ class SelectFieldBloc<Value, ExtraData> extends SingleFieldBloc<Value?, Value,
   void removeItem(Value item) {
     var items = state.items;
     if (items.isNotEmpty) {
-      items = SingleFieldBloc._itemsWithoutDuplicates(
-          List<Value>.from(items)..remove(item));
+      items = SingleFieldBloc._itemsWithoutDuplicates([...items]..remove(item));
       emit(state.copyWith(
         items: items,
         value: items.contains(value) ? null : Param(null),

--- a/packages/form_bloc/lib/src/blocs/select_field/select_field_state.dart
+++ b/packages/form_bloc/lib/src/blocs/select_field/select_field_state.dart
@@ -5,9 +5,12 @@ class SelectFieldBlocState<Value, ExtraData>
   final List<Value> items;
 
   SelectFieldBlocState({
+    required bool isValueChanged,
+    required Value? initialValue,
+    required Value? updatedValue,
     required Value? value,
     required Object? error,
-    required bool isInitial,
+    required bool isDirty,
     required Suggestions<Value>? suggestions,
     required bool isValidated,
     required bool isValidating,
@@ -17,9 +20,12 @@ class SelectFieldBlocState<Value, ExtraData>
     dynamic Function(Value? value)? toJson,
     ExtraData? extraData,
   }) : super(
+          isValueChanged: isValueChanged,
+          initialValue: initialValue,
+          updatedValue: updatedValue,
           value: value,
           error: error,
-          isInitial: isInitial,
+          isDirty: isDirty,
           suggestions: suggestions,
           isValidated: isValidated,
           isValidating: isValidating,
@@ -31,9 +37,12 @@ class SelectFieldBlocState<Value, ExtraData>
 
   @override
   SelectFieldBlocState<Value, ExtraData> copyWith({
+    bool? isValueChanged,
+    Param<Value?>? initialValue,
+    Param<Value?>? updatedValue,
     Param<Value?>? value,
     Param<Object?>? error,
-    bool? isInitial,
+    bool? isDirty,
     Param<Suggestions<Value>?>? suggestions,
     bool? isValidated,
     bool? isValidating,
@@ -42,9 +51,12 @@ class SelectFieldBlocState<Value, ExtraData>
     Param<ExtraData?>? extraData,
   }) {
     return SelectFieldBlocState(
+      isValueChanged: isValueChanged ?? this.isValueChanged,
+      initialValue: initialValue.or(this.initialValue),
+      updatedValue: updatedValue.or(this.updatedValue),
       value: value == null ? this.value : value.value,
       error: error == null ? this.error : error.value,
-      isInitial: isInitial ?? this.isInitial,
+      isDirty: isDirty ?? this.isDirty,
       suggestions: suggestions == null ? this.suggestions : suggestions.value,
       isValidated: isValidated ?? this.isValidated,
       isValidating: isValidating ?? this.isValidating,
@@ -55,45 +67,11 @@ class SelectFieldBlocState<Value, ExtraData>
       extraData: extraData == null ? this.extraData : extraData.value,
     );
   }
-  // @override
-  // SelectFieldBlocState<Value, ExtraData> copyWith(
-  //     {Optional<List<Value>>? value,
-  //     Optional<String>? error,
-  //     bool? isInitial,
-  //     Optional<Suggestions<Value>>? suggestions,
-  //     bool? isValidated,
-  //     bool? isValidating,
-  //     FormBloc? formBloc,
-  //     Optional<List<Value>>? items,
-  //     Optional<ExtraData?>? extraData}) {
-  //   return SelectFieldBlocState(
-  //     value: value == null ? this.value : value.orNull,
-  //     error: error == null ? this.error : error.orNull,
-  //     isInitial: isInitial ?? this.isInitial,
-  //     suggestions: suggestions == null ? this.suggestions : suggestions.orNull,
-  //     isValidated: isValidated ?? this.isValidated,
-  //     isValidating: isValidating ?? this.isValidating,
-  //     formBloc: formBloc ?? this.formBloc,
-  //     name: name,
-  //     items: items == null ? this.items : items.orNull,
-  //     toJson: _toJson,
-  //     extraData: extraData == null ? this.extraData : extraData.orNull,
-  //   );
-  // }
 
   @override
-  String toString() => _toStringWith(',\n  items: $items');
+  String toString([String extra = '']) =>
+      super.toString(',\n  items: $items$extra');
 
   @override
-  List<Object?> get props => [
-        value,
-        error,
-        isInitial,
-        suggestions,
-        isValidated,
-        isValidating,
-        extraData,
-        formBloc,
-        items,
-      ];
+  List<Object?> get props => [super.props, items];
 }

--- a/packages/form_bloc/lib/src/blocs/text_field/text_field_bloc.dart
+++ b/packages/form_bloc/lib/src/blocs/text_field/text_field_bloc.dart
@@ -46,21 +46,19 @@ class TextFieldBloc<ExtraData> extends SingleFieldBloc<String, String,
     Suggestions<String>? suggestions,
     ExtraData? extraData,
   }) : super(
-          initialValue,
-          validators,
-          asyncValidators,
-          asyncValidatorDebounceTime,
-          suggestions,
-          name,
-          (value) => value,
-          extraData,
-          TextFieldBlocState(
+          validators: validators,
+          asyncValidators: asyncValidators,
+          asyncValidatorDebounceTime: asyncValidatorDebounceTime,
+          initialState: TextFieldBlocState(
+            isValueChanged: false,
+            initialValue: initialValue,
+            updatedValue: initialValue,
             value: initialValue,
             error: FieldBlocUtils.getInitialStateError(
               validators: validators,
               value: initialValue,
             ),
-            isInitial: true,
+            isDirty: false,
             suggestions: suggestions,
             isValidated: FieldBlocUtils.getInitialIsValidated(
               FieldBlocUtils.getInitialStateIsValidating(
@@ -91,10 +89,4 @@ class TextFieldBloc<ExtraData> extends SingleFieldBloc<String, String,
   /// if the `value` is a `double` returns the parsed `value`,
   /// else returns `null`.
   double? get valueToDouble => state.valueToDouble;
-
-  /// Set the `value` to `''` of the current state.
-  ///
-  /// {@macro form_bloc.field_bloc.update_value}
-  @override
-  void clear() => updateInitialValue('');
 }

--- a/packages/form_bloc/lib/src/blocs/text_field/text_field_state.dart
+++ b/packages/form_bloc/lib/src/blocs/text_field/text_field_state.dart
@@ -3,9 +3,12 @@ part of '../field/field_bloc.dart';
 class TextFieldBlocState<ExtraData>
     extends FieldBlocState<String, String, ExtraData?> {
   TextFieldBlocState({
+    required bool isValueChanged,
+    required String initialValue,
+    required String updatedValue,
     required String value,
     required Object? error,
-    required bool isInitial,
+    required bool isDirty,
     required Suggestions<String>? suggestions,
     required bool isValidated,
     required bool isValidating,
@@ -14,9 +17,12 @@ class TextFieldBlocState<ExtraData>
     dynamic Function(String value)? toJson,
     ExtraData? extraData,
   }) : super(
+          isValueChanged: isValueChanged,
+          initialValue: initialValue,
+          updatedValue: updatedValue,
           value: value,
           error: error,
-          isInitial: isInitial,
+          isDirty: isDirty,
           suggestions: suggestions,
           isValidated: isValidated,
           isValidating: isValidating,
@@ -38,9 +44,12 @@ class TextFieldBlocState<ExtraData>
 
   @override
   TextFieldBlocState<ExtraData> copyWith({
+    bool? isValueChanged,
+    Param<String>? initialValue,
+    Param<String>? updatedValue,
     Param<String>? value,
     Param<Object?>? error,
-    bool? isInitial,
+    bool? isDirty,
     Param<Suggestions<String>?>? suggestions,
     bool? isValidated,
     bool? isValidating,
@@ -48,9 +57,12 @@ class TextFieldBlocState<ExtraData>
     Param<ExtraData?>? extraData,
   }) {
     return TextFieldBlocState(
+      isValueChanged: isValueChanged ?? this.isValueChanged,
+      initialValue: initialValue.or(this.initialValue),
+      updatedValue: updatedValue.or(this.updatedValue),
       value: value == null ? this.value : value.value,
       error: error == null ? this.error : error.value,
-      isInitial: isInitial ?? this.isInitial,
+      isDirty: isDirty ?? this.isDirty,
       suggestions: suggestions == null ? this.suggestions : suggestions.value,
       isValidated: isValidated ?? this.isValidated,
       isValidating: isValidating ?? this.isValidating,
@@ -60,16 +72,4 @@ class TextFieldBlocState<ExtraData>
       extraData: extraData == null ? this.extraData : extraData.value,
     );
   }
-
-  @override
-  List<Object?> get props => [
-        value,
-        error,
-        isInitial,
-        suggestions,
-        isValidated,
-        isValidating,
-        extraData,
-        formBloc,
-      ];
 }

--- a/packages/form_bloc/lib/src/extension/extension.dart
+++ b/packages/form_bloc/lib/src/extension/extension.dart
@@ -7,3 +7,7 @@ extension StreamExtension<T> on Stream<T> {
     }
   }
 }
+
+extension RemoveAllListExtension<T> on List<T> {
+  void removeAll(Iterable<T> elements) => elements.forEach(remove);
+}

--- a/packages/form_bloc/lib/src/utils.dart
+++ b/packages/form_bloc/lib/src/utils.dart
@@ -3,3 +3,7 @@ class Param<T> {
 
   const Param(this.value);
 }
+
+extension ParamCopyWithExtension<T> on Param<T>? {
+  T or(T value) => this == null ? value : this!.value;
+}

--- a/packages/form_bloc/pubspec.yaml
+++ b/packages/form_bloc/pubspec.yaml
@@ -20,5 +20,6 @@ dev_dependencies:
   test: ^1.20.1
   mocktail: ^0.2.0
   bloc_test: ^9.0.2
+  fire_line_diff: ^1.5.3
 
   lints: ^1.0.1

--- a/packages/form_bloc/test/boolean_field/boolean_field_bloc_test.dart
+++ b/packages/form_bloc/test/boolean_field/boolean_field_bloc_test.dart
@@ -2,6 +2,8 @@ import 'package:form_bloc/form_bloc.dart';
 import 'package:form_bloc/src/utils.dart';
 import 'package:test/test.dart';
 
+import '../utils/states.dart';
+
 void main() {
   group('BooleanFieldBloc:', () {
     group('constructor:', () {
@@ -17,18 +19,21 @@ void main() {
         );
 
         final state1 = BooleanFieldBlocState<dynamic>(
+          isValueChanged: false,
+          initialValue: false,
+          updatedValue: false,
           value: false,
           error: null,
-          isInitial: true,
+          isDirty: false,
           suggestions: suggestions,
           isValidated: true,
           isValidating: false,
           name: 'name',
         );
         final state2 = state1.copyWith(
+          updatedValue: Param(true),
           value: Param(true),
           error: Param('error'),
-          isInitial: false,
         );
 
         final expectedStates = [
@@ -51,10 +56,10 @@ void main() {
           name: 'name',
         );
 
-        initialState = BooleanFieldBlocState<dynamic>(
+        initialState = createBooleanState<dynamic>(
           value: false,
           error: null,
-          isInitial: true,
+          isDirty: false,
           suggestions: null,
           isValidated: true,
           isValidating: false,
@@ -74,10 +79,10 @@ void main() {
           validators: [FieldBlocValidators.required, (value) => 'error'],
         );
 
-        initialState = BooleanFieldBlocState<dynamic>(
+        initialState = createBooleanState<dynamic>(
           value: true,
           error: 'error',
-          isInitial: true,
+          isDirty: false,
           suggestions: null,
           isValidated: true,
           isValidating: false,
@@ -89,16 +94,17 @@ void main() {
           initialState,
         );
       });
+
       test('if the initialValue is not passed, it will be false', () {
         BooleanFieldBloc fieldBloc;
         BooleanFieldBlocState initialState;
 
         fieldBloc = BooleanFieldBloc<dynamic>(name: 'name');
 
-        initialState = BooleanFieldBlocState<dynamic>(
+        initialState = createBooleanState<dynamic>(
           value: false,
           error: null,
-          isInitial: true,
+          isDirty: false,
           suggestions: null,
           isValidated: true,
           isValidating: false,
@@ -110,39 +116,6 @@ void main() {
           initialState,
         );
       });
-
-      test('clear method.', () {
-        final fieldBloc = BooleanFieldBloc<dynamic>(
-          name: 'name',
-          initialValue: true,
-        );
-
-        final state1 = BooleanFieldBlocState<dynamic>(
-          value: false,
-          error: null,
-          isInitial: false,
-          suggestions: null,
-          isValidated: true,
-          isValidating: false,
-          name: 'name',
-        );
-        final state2 = state1.copyWith(
-          value: Param(false),
-          isInitial: true,
-        );
-
-        final expectedStates = [
-          state1,
-          state2,
-        ];
-        expect(
-          fieldBloc.stream,
-          emitsInOrder(expectedStates),
-        );
-
-        fieldBloc.updateValue(false);
-        fieldBloc.clear();
-      }, timeout: Timeout(Duration(minutes: 1)));
     });
 
     test('toJson return value', () async {

--- a/packages/form_bloc/test/boolean_field/boolean_field_state_test.dart
+++ b/packages/form_bloc/test/boolean_field/boolean_field_state_test.dart
@@ -2,59 +2,114 @@ import 'package:form_bloc/form_bloc.dart';
 import 'package:form_bloc/src/utils.dart';
 import 'package:test/test.dart';
 
+import '../utils/when_bloc.dart';
+
 void main() {
   group('BooleanFieldBlocState:', () {
-    test('copyWith.', () {
+    group('copyWith', () {
       Future<List<bool>> suggestions(String pattern) async => [true];
 
-      final state = BooleanFieldBlocState<dynamic>(
-        value: false,
-        error: null,
-        isInitial: false,
-        suggestions: null,
-        isValidated: false,
-        isValidating: false,
-        name: 'name',
-      );
-      final stateCopy1 = state.copyWith(
-        value: Param(true),
-        error: Param('error'),
-        isInitial: true,
-        suggestions: Param(suggestions),
-        isValidated: true,
-      );
-      final stateCopy2 = stateCopy1.copyWith(
-        value: Param(false),
-        error: Param(null),
-        isInitial: false,
-        suggestions: Param(null),
-        isValidated: false,
-      );
-      final stateCopy3 = stateCopy2.copyWith();
+      test('copyWith add values', () {
+        final state1 = BooleanFieldBlocState<String>(
+          isValueChanged: false,
+          initialValue: false,
+          updatedValue: false,
+          value: false,
+          error: null,
+          suggestions: null,
+          isDirty: false,
+          isValidated: false,
+          isValidating: false,
+          name: 'fieldName',
+        );
 
-      final statesCopies = [
-        // stateCopy1,
-        stateCopy2,
-        stateCopy3,
-      ];
+        expectState(
+          state1.copyWith(
+            isValueChanged: true,
+            initialValue: Param(true),
+            updatedValue: Param(true),
+            value: Param(true),
+            error: Param('error'),
+            suggestions: Param(suggestions),
+            isDirty: true,
+            isValidated: true,
+            isValidating: true,
+          ),
+          BooleanFieldBlocState<String>(
+            isValueChanged: true,
+            initialValue: true,
+            updatedValue: true,
+            value: true,
+            error: 'error',
+            suggestions: suggestions,
+            isDirty: true,
+            isValidated: true,
+            isValidating: true,
+            name: 'fieldName',
+          ),
+        );
+      });
 
-      final expectedStates = [
-        // BooleanFieldBlocState<dynamic>(
-        //   value: true,
-        //   error: 'error',
-        //   isInitial: true,
-        //   suggestions: suggestions,
-        //   isValidated: true,
-        //   isValidating: false,
-        //   name: null,
-        // ),
-        state,
-        state,
-      ];
-      expect(
-        statesCopies,
-        expectedStates,
-      );
+      test('copyWith remove values', () {
+        final state1 = BooleanFieldBlocState<String>(
+          isValueChanged: true,
+          initialValue: true,
+          updatedValue: true,
+          value: true,
+          error: 'error',
+          suggestions: suggestions,
+          isDirty: true,
+          isValidated: true,
+          isValidating: true,
+          name: 'fieldName',
+        );
+
+        expectState(
+          state1.copyWith(
+            isValueChanged: false,
+            initialValue: Param(false),
+            updatedValue: Param(false),
+            value: Param(false),
+            error: Param(null),
+            suggestions: Param(null),
+            isDirty: false,
+            isValidated: false,
+            isValidating: false,
+          ),
+          BooleanFieldBlocState<String>(
+            isValueChanged: false,
+            initialValue: false,
+            updatedValue: false,
+            value: false,
+            error: null,
+            suggestions: null,
+            isDirty: false,
+            isValidated: false,
+            isValidating: false,
+            name: 'fieldName',
+          ),
+        );
+      });
+
+      test('copyWith none', () {
+        final state1 = BooleanFieldBlocState<String>(
+          isValueChanged: true,
+          initialValue: true,
+          updatedValue: true,
+          value: true,
+          error: 'error',
+          suggestions: suggestions,
+          isDirty: true,
+          isValidated: true,
+          isValidating: true,
+          name: 'fieldName',
+        );
+
+        expectState(
+          state1.copyWith(),
+          state1,
+        );
+      });
     });
   });
 }

--- a/packages/form_bloc/test/field_bloc/multi_field_bloc_test.dart
+++ b/packages/form_bloc/test/field_bloc/multi_field_bloc_test.dart
@@ -124,11 +124,11 @@ void main() {
           fieldBlocs: [field],
           formBloc: formBloc,
         );
-        final expectedBoolUpdate = BooleanFieldBlocState<Object>(
+        final expectedBoolUpdate = createBooleanState<Object>(
           name: 'bool',
           value: false,
           error: null,
-          isInitial: true,
+          isDirty: false,
           suggestions: null,
           isValidated: false,
           isValidating: false,
@@ -163,11 +163,11 @@ void main() {
           fieldBlocs: [field],
           formBloc: formBloc,
         );
-        final expectedBoolUpdate = BooleanFieldBlocState<Object>(
+        final expectedBoolUpdate = createBooleanState<Object>(
           name: 'bool',
           value: false,
           error: null,
-          isInitial: true,
+          isDirty: false,
           suggestions: null,
           isValidated: false,
           isValidating: false,

--- a/packages/form_bloc/test/form_bloc/form_bloc_utils_test.dart
+++ b/packages/form_bloc/test/form_bloc/form_bloc_utils_test.dart
@@ -808,12 +808,12 @@ void main() {
 
         expect(
           booleanFieldBloc.state,
-          BooleanFieldBlocState<dynamic>(
+          createBooleanState<dynamic>(
             name: '',
             formBloc: formBloc,
             value: false,
             error: null,
-            isInitial: true,
+            isDirty: false,
             suggestions: null,
             isValidated: false,
             isValidating: false,
@@ -827,12 +827,12 @@ void main() {
 
         expect(
           booleanFieldBloc.state,
-          BooleanFieldBlocState<dynamic>(
+          createBooleanState<dynamic>(
             name: '',
             formBloc: null,
             value: false,
             error: null,
-            isInitial: true,
+            isDirty: false,
             suggestions: null,
             isValidated: false,
             isValidating: false,
@@ -908,6 +908,39 @@ void main() {
           ),
         );
       });
+    });
+
+    test('isValuesChanged', () {
+      final singleFieldBloc = BooleanFieldBloc<dynamic>();
+      final multiFieldBloc = ListFieldBloc<FieldBloc, dynamic>(
+        fieldBlocs: [singleFieldBloc],
+      );
+
+      singleFieldBloc.changeValue(true);
+
+      expect(FormBlocUtils.isValuesChanged([multiFieldBloc]), true);
+    });
+
+    test('hasInitialValues', () {
+      final singleFieldBloc = BooleanFieldBloc<dynamic>();
+      final multiFieldBloc = ListFieldBloc<FieldBloc, dynamic>(
+        fieldBlocs: [singleFieldBloc],
+      );
+
+      singleFieldBloc.changeValue(true);
+
+      expect(FormBlocUtils.hasInitialValues([multiFieldBloc]), false);
+    });
+
+    test('hasUpdatedValues', () {
+      final singleFieldBloc = BooleanFieldBloc<dynamic>();
+      final multiFieldBloc = ListFieldBloc<FieldBloc, dynamic>(
+        fieldBlocs: [singleFieldBloc],
+      );
+
+      singleFieldBloc.changeValue(true);
+
+      expect(FormBlocUtils.hasInitialValues([multiFieldBloc]), false);
     });
   });
 }

--- a/packages/form_bloc/test/input_field/input_field_bloc_test.dart
+++ b/packages/form_bloc/test/input_field/input_field_bloc_test.dart
@@ -2,6 +2,8 @@ import 'package:form_bloc/form_bloc.dart';
 import 'package:form_bloc/src/utils.dart';
 import 'package:test/test.dart';
 
+import '../utils/states.dart';
+
 void main() {
   group('InputFieldBloc:', () {
     group('constructor:', () {
@@ -19,19 +21,19 @@ void main() {
           suggestions: suggestions,
         );
 
-        final state1 = InputFieldBlocState<bool?, dynamic>(
+        final state1 = createInputState<bool?, dynamic>(
           value: null,
           error: FieldBlocValidatorsErrors.required,
-          isInitial: true,
+          isDirty: false,
           suggestions: suggestions,
           isValidated: true,
           isValidating: false,
           name: 'name',
         );
         final state2 = state1.copyWith(
+          updatedValue: Param(true),
           value: Param(true),
           error: Param('error'),
-          isInitial: false,
         );
 
         final expectedStates = [
@@ -56,10 +58,10 @@ void main() {
         initialValue: null,
       );
 
-      initialState = InputFieldBlocState<bool?, dynamic>(
+      initialState = createInputState<bool?, dynamic>(
         value: null,
         error: null,
-        isInitial: true,
+        isDirty: false,
         suggestions: null,
         isValidated: true,
         isValidating: false,
@@ -79,10 +81,10 @@ void main() {
         validators: [(value) => 'error'],
       );
 
-      initialState = InputFieldBlocState<bool, dynamic>(
+      initialState = createInputState<bool, dynamic>(
         value: true,
         error: 'error',
-        isInitial: true,
+        isDirty: false,
         suggestions: null,
         isValidated: true,
         isValidating: false,

--- a/packages/form_bloc/test/input_field/input_field_state_test.dart
+++ b/packages/form_bloc/test/input_field/input_field_state_test.dart
@@ -2,59 +2,114 @@ import 'package:form_bloc/form_bloc.dart';
 import 'package:form_bloc/src/utils.dart';
 import 'package:test/test.dart';
 
+import '../utils/when_bloc.dart';
+
 void main() {
   group('InputFieldBlocState:', () {
-    test('copyWith.', () {
+    group('copyWith', () {
       Future<List<int>> suggestions(String pattern) async => [1];
 
-      final state = InputFieldBlocState<int?, dynamic>(
-        value: null,
-        error: null,
-        isInitial: false,
-        suggestions: null,
-        isValidated: false,
-        isValidating: false,
-        name: '',
-      );
-      final stateCopy1 = state.copyWith(
-        value: Param(1),
-        error: Param('error'),
-        isInitial: true,
-        suggestions: Param(suggestions),
-        isValidated: true,
-      );
-      final stateCopy2 = stateCopy1.copyWith(
-        value: Param(null),
-        error: Param(null),
-        isInitial: false,
-        suggestions: Param(null),
-        isValidated: false,
-      );
-      final stateCopy3 = stateCopy2.copyWith();
+      test('copyWith add values', () {
+        final state1 = InputFieldBlocState<int?, String>(
+          isValueChanged: false,
+          initialValue: null,
+          updatedValue: null,
+          value: null,
+          error: null,
+          suggestions: null,
+          isDirty: false,
+          isValidated: false,
+          isValidating: false,
+          name: 'fieldName',
+        );
 
-      final statesCopies = [
-        // stateCopy1,
-        stateCopy2,
-        stateCopy3,
-      ];
+        expectState(
+          state1.copyWith(
+            isValueChanged: true,
+            initialValue: Param(0),
+            updatedValue: Param(0),
+            value: Param(0),
+            error: Param('error'),
+            suggestions: Param(suggestions),
+            isDirty: true,
+            isValidated: true,
+            isValidating: true,
+          ),
+          InputFieldBlocState<int?, String>(
+            isValueChanged: true,
+            initialValue: 0,
+            updatedValue: 0,
+            value: 0,
+            error: 'error',
+            suggestions: suggestions,
+            isDirty: true,
+            isValidated: true,
+            isValidating: true,
+            name: 'fieldName',
+          ),
+        );
+      });
 
-      final expectedStates = [
-        // InputFieldBlocState<int, dynamic>(
-        //   value: 1,
-        //   error: 'error',
-        //   isInitial: true,
-        //   suggestions: suggestions,
-        //   isValidated: true,
-        //   isValidating: false,
-        //   name: null,
-        // ),
-        state,
-        state,
-      ];
-      expect(
-        statesCopies,
-        expectedStates,
-      );
+      test('copyWith remove values', () {
+        final state1 = InputFieldBlocState<int?, String>(
+          isValueChanged: true,
+          initialValue: 0,
+          updatedValue: 0,
+          value: 0,
+          error: 'error',
+          suggestions: suggestions,
+          isDirty: true,
+          isValidated: true,
+          isValidating: true,
+          name: 'fieldName',
+        );
+
+        expectState(
+          state1.copyWith(
+            isValueChanged: false,
+            initialValue: Param(null),
+            updatedValue: Param(null),
+            value: Param(null),
+            error: Param(null),
+            suggestions: Param(null),
+            isDirty: false,
+            isValidated: false,
+            isValidating: false,
+          ),
+          InputFieldBlocState<int?, String>(
+            isValueChanged: false,
+            initialValue: null,
+            updatedValue: null,
+            value: null,
+            error: null,
+            suggestions: null,
+            isDirty: false,
+            isValidated: false,
+            isValidating: false,
+            name: 'fieldName',
+          ),
+        );
+      });
+
+      test('copyWith none', () {
+        final state1 = InputFieldBlocState<int, String>(
+          isValueChanged: true,
+          initialValue: 0,
+          updatedValue: 0,
+          value: 0,
+          error: 'error',
+          suggestions: suggestions,
+          isDirty: true,
+          isValidated: true,
+          isValidating: true,
+          name: 'fieldName',
+        );
+
+        expectState(
+          state1.copyWith(),
+          state1,
+        );
+      });
     });
   });
 }

--- a/packages/form_bloc/test/multi_select_field/multi_select_field_bloc_test.dart
+++ b/packages/form_bloc/test/multi_select_field/multi_select_field_bloc_test.dart
@@ -2,6 +2,9 @@ import 'package:form_bloc/form_bloc.dart';
 import 'package:form_bloc/src/utils.dart';
 import 'package:test/test.dart';
 
+import '../utils/states.dart';
+import '../utils/when_bloc.dart';
+
 void main() {
   group('MultiSelectFieldBloc:', () {
     group('constructor:', () {
@@ -19,10 +22,10 @@ void main() {
           suggestions: suggestions,
         );
 
-        final state1 = MultiSelectFieldBlocState<bool, dynamic>(
+        final state1 = createMultiSelectState<bool, dynamic>(
           value: [],
           error: FieldBlocValidatorsErrors.required,
-          isInitial: true,
+          isDirty: false,
           suggestions: suggestions,
           isValidated: true,
           isValidating: false,
@@ -30,9 +33,9 @@ void main() {
           items: [],
         );
         final state2 = state1.copyWith(
+          updatedValue: Param([true]),
           value: Param([true]),
           error: Param('error'),
-          isInitial: false,
         );
 
         final expectedStates = [
@@ -56,10 +59,10 @@ void main() {
         name: 'name',
       );
 
-      initialState = MultiSelectFieldBlocState<bool, dynamic>(
+      initialState = createMultiSelectState<bool, dynamic>(
         value: [],
         error: null,
-        isInitial: true,
+        isDirty: false,
         suggestions: null,
         isValidated: true,
         isValidating: false,
@@ -81,10 +84,10 @@ void main() {
         items: [true, false],
       );
 
-      initialState = MultiSelectFieldBlocState<bool, dynamic>(
+      initialState = createMultiSelectState<bool, dynamic>(
         value: [true],
         error: 'error',
-        isInitial: true,
+        isDirty: false,
         suggestions: null,
         isValidated: true,
         isValidating: false,
@@ -103,10 +106,10 @@ void main() {
 
       fieldBloc = MultiSelectFieldBloc<bool, dynamic>(name: 'name');
 
-      initialState = MultiSelectFieldBlocState<bool, dynamic>(
+      initialState = createMultiSelectState<bool, dynamic>(
         value: [],
         error: null,
-        isInitial: true,
+        isDirty: false,
         suggestions: null,
         isValidated: true,
         isValidating: false,
@@ -125,10 +128,10 @@ void main() {
         name: 'name',
       );
 
-      final state1 = MultiSelectFieldBlocState<bool, dynamic>(
+      final state1 = createMultiSelectState<bool, dynamic>(
         value: [],
         error: null,
-        isInitial: true,
+        isDirty: false,
         suggestions: null,
         isValidated: true,
         isValidating: false,
@@ -162,10 +165,10 @@ void main() {
         items: [true],
       );
 
-      final state1 = MultiSelectFieldBlocState<bool, dynamic>(
+      final state1 = createMultiSelectState<bool, dynamic>(
         value: [],
         error: null,
-        isInitial: true,
+        isDirty: false,
         suggestions: null,
         isValidated: true,
         isValidating: false,
@@ -204,10 +207,10 @@ void main() {
         items: [true, false],
       );
 
-      final state1 = MultiSelectFieldBlocState<bool, dynamic>(
+      final state1 = createMultiSelectState<bool, dynamic>(
         value: [],
         error: null,
-        isInitial: true,
+        isDirty: false,
         suggestions: null,
         isValidated: true,
         isValidating: false,
@@ -241,10 +244,10 @@ void main() {
         name: 'name',
       );
 
-      final state1 = MultiSelectFieldBlocState<bool, dynamic>(
+      final state1 = createMultiSelectState<bool, dynamic>(
         value: [],
         error: null,
-        isInitial: true,
+        isDirty: false,
         suggestions: null,
         isValidated: true,
         isValidating: false,
@@ -252,13 +255,15 @@ void main() {
         items: [],
       );
       final state2 = state1.copyWith(
+        updatedValue: Param([true]),
         value: Param([true]),
-        isInitial: false,
       );
       final state3 = state2.copyWith(
+        updatedValue: Param([false, true]),
         value: Param([false, true]),
       );
       final state4 = state3.copyWith(
+        updatedValue: Param([]),
         value: Param([]),
       );
 
@@ -283,10 +288,10 @@ void main() {
         name: 'name',
       );
 
-      final state1 = MultiSelectFieldBlocState<bool, dynamic>(
+      final state1 = createMultiSelectState<bool, dynamic>(
         value: [],
         error: null,
-        isInitial: true,
+        isDirty: false,
         suggestions: null,
         isValidated: true,
         isValidating: false,
@@ -294,14 +299,17 @@ void main() {
         items: [],
       );
       final state2 = state1.copyWith(
+        updatedValue: Param([true]),
         value: Param([true]),
-        isInitial: false,
       );
       final state3 = state2.copyWith(
+        initialValue: Param([false, true]),
+        updatedValue: Param([false, true]),
         value: Param([false, true]),
-        isInitial: true,
       );
       final state4 = state3.copyWith(
+        initialValue: Param([]),
+        updatedValue: Param([]),
         value: Param([]),
       );
 
@@ -324,30 +332,34 @@ void main() {
     test('select method SelectMultiSelectFieldBlocValue event.', () {
       final fieldBloc = MultiSelectFieldBloc<bool?, dynamic>(
         name: 'name',
+        items: [null, false, true],
       );
 
-      final state1 = MultiSelectFieldBlocState<bool?, dynamic>(
+      final state1 = createMultiSelectState<bool?, dynamic>(
         value: [],
         error: null,
-        isInitial: true,
+        isDirty: false,
         suggestions: null,
         isValidated: true,
         isValidating: false,
         name: 'name',
-        items: [],
+        items: [null, false, true],
       );
       final state2 = state1.copyWith(
+        isValueChanged: true,
         error: Param(null),
         value: Param([true]),
-        isInitial: false,
       );
       final state3 = state2.copyWith(
         value: Param([true, false]),
       );
       final state4 = state3.copyWith(
+        isValueChanged: false,
+        updatedValue: Param([]),
         value: Param([]),
       );
       final state5 = state4.copyWith(
+        isValueChanged: true,
         error: Param(null),
         value: Param([false]),
       );
@@ -378,30 +390,36 @@ void main() {
 
     test('deselect method DeselectMultiSelectFieldBlocValue event.', () {
       final fieldBloc = MultiSelectFieldBloc<bool?, dynamic>(
-          name: 'name', initialValue: [true, false]);
+        name: 'name',
+        initialValue: [true, false],
+        items: [null, false, true],
+      );
 
-      final state1 = MultiSelectFieldBlocState<bool?, dynamic>(
+      final state1 = createMultiSelectState<bool?, dynamic>(
         value: [true, false],
         error: null,
-        isInitial: true,
+        isDirty: false,
         suggestions: null,
         isValidated: true,
         isValidating: false,
         name: 'name',
-        items: [],
+        items: [null, false, true],
       );
       final state2 = state1.copyWith(
+        isValueChanged: true,
         value: Param([false]),
-        isInitial: false,
       );
       final state3 = state2.copyWith(
         value: Param([]),
       );
       final state4 = state3.copyWith(
+        isValueChanged: false,
+        updatedValue: Param([true, false, null]),
         error: Param(null),
         value: Param([true, false, null]),
       );
       final state5 = state4.copyWith(
+        isValueChanged: true,
         value: Param([true, false]),
       );
       final state6 = state5.copyWith(
@@ -417,10 +435,7 @@ void main() {
         state6,
       ];
 
-      expect(
-        fieldBloc.stream,
-        emitsInOrder(expectedStates),
-      );
+      expectBloc(fieldBloc, stream: expectedStates);
 
       fieldBloc.deselect(true);
       fieldBloc.deselect(true);

--- a/packages/form_bloc/test/multi_select_field/multi_select_field_state_test.dart
+++ b/packages/form_bloc/test/multi_select_field/multi_select_field_state_test.dart
@@ -2,63 +2,121 @@ import 'package:form_bloc/form_bloc.dart';
 import 'package:form_bloc/src/utils.dart';
 import 'package:test/test.dart';
 
+import '../utils/when_bloc.dart';
+
 void main() {
   group('MultiSelectFieldBlocState:', () {
-    test('copyWith.', () {
+    group('copyWith', () {
       Future<List<int>> suggestions(String pattern) async => [1];
 
-      final state = MultiSelectFieldBlocState<int?, dynamic>(
-        value: [],
-        error: null,
-        isInitial: false,
-        suggestions: null,
-        isValidated: false,
-        isValidating: false,
-        name: '',
-        items: [],
-      );
-      final stateCopy1 = state.copyWith(
-        value: Param([1]),
-        error: Param('error'),
-        isInitial: true,
-        suggestions: Param(suggestions),
-        isValidated: true,
-        items: [1],
-      );
-      final stateCopy2 = stateCopy1.copyWith(
-        value: Param([]),
-        error: Param(null),
-        isInitial: false,
-        suggestions: Param(null),
-        isValidated: false,
-        items: [],
-      );
-      final stateCopy3 = stateCopy2.copyWith();
+      test('copyWith add values', () {
+        final state1 = MultiSelectFieldBlocState<int, String>(
+          isValueChanged: false,
+          initialValue: [],
+          updatedValue: [],
+          value: [],
+          error: null,
+          suggestions: null,
+          isDirty: false,
+          isValidated: false,
+          isValidating: false,
+          name: 'fieldName',
+          items: [],
+        );
 
-      final statesCopies = [
-        // stateCopy1,
-        stateCopy2,
-        stateCopy3,
-      ];
+        expectState(
+          state1.copyWith(
+            isValueChanged: true,
+            initialValue: Param([0]),
+            updatedValue: Param([0]),
+            value: Param([0]),
+            error: Param('error'),
+            suggestions: Param(suggestions),
+            isDirty: true,
+            isValidated: true,
+            isValidating: true,
+            items: [1],
+          ),
+          MultiSelectFieldBlocState<int, String>(
+            isValueChanged: true,
+            initialValue: [0],
+            updatedValue: [0],
+            value: [0],
+            error: 'error',
+            suggestions: suggestions,
+            isDirty: true,
+            isValidated: true,
+            isValidating: true,
+            name: 'fieldName',
+            items: [1],
+          ),
+        );
+      });
 
-      final expectedStates = [
-        // MultiSelectFieldBlocState<int, dynamic>(
-        //   value: [1],
-        //   error: 'error',
-        //   isInitial: true,
-        //   suggestions: suggestions,
-        //   isValidated: true,
-        //   isValidating: false,
-        //   name: null,
-        //   items: [1],
-        // ),
-        state,
-        state,
-      ];
-      expect(
-        statesCopies,
-        expectedStates,
-      );
+      test('copyWith remove values', () {
+        final state1 = MultiSelectFieldBlocState<int, String>(
+          isValueChanged: true,
+          initialValue: [0],
+          updatedValue: [0],
+          value: [0],
+          error: 'error',
+          suggestions: suggestions,
+          isDirty: true,
+          isValidated: true,
+          isValidating: true,
+          name: 'fieldName',
+          items: [1],
+        );
+
+        expectState(
+          state1.copyWith(
+            isValueChanged: false,
+            initialValue: Param([]),
+            updatedValue: Param([]),
+            value: Param([]),
+            error: Param(null),
+            suggestions: Param(null),
+            isDirty: false,
+            isValidated: false,
+            isValidating: false,
+            items: [],
+          ),
+          MultiSelectFieldBlocState<int, String>(
+            isValueChanged: false,
+            initialValue: [],
+            updatedValue: [],
+            value: [],
+            error: null,
+            suggestions: null,
+            isDirty: false,
+            isValidated: false,
+            isValidating: false,
+            name: 'fieldName',
+            items: [],
+          ),
+        );
+      });
+
+      test('copyWith none', () {
+        final state1 = MultiSelectFieldBlocState<int, String>(
+          isValueChanged: true,
+          initialValue: [0],
+          updatedValue: [0],
+          value: [0],
+          error: 'error',
+          suggestions: suggestions,
+          isDirty: true,
+          isValidated: true,
+          isValidating: true,
+          name: 'fieldName',
+          items: [1],
+        );
+
+        expectState(
+          state1.copyWith(),
+          state1,
+        );
+      });
     });
 
     test('If toJson is null, return value', () async {

--- a/packages/form_bloc/test/select_field/select_field_bloc_test.dart
+++ b/packages/form_bloc/test/select_field/select_field_bloc_test.dart
@@ -2,6 +2,8 @@ import 'package:form_bloc/form_bloc.dart';
 import 'package:form_bloc/src/utils.dart';
 import 'package:test/test.dart';
 
+import '../utils/states.dart';
+
 void main() {
   group('SelectFieldBloc:', () {
     group('constructor:', () {
@@ -19,10 +21,10 @@ void main() {
           suggestions: suggestions,
         );
 
-        final state1 = SelectFieldBlocState<bool, dynamic>(
-          value: null,
+        final state1 = createSelectState<bool, dynamic>(
+          value: false,
           error: FieldBlocValidatorsErrors.required,
-          isInitial: true,
+          isDirty: false,
           suggestions: suggestions,
           isValidated: true,
           isValidating: false,
@@ -30,9 +32,9 @@ void main() {
           items: [],
         );
         final state2 = state1.copyWith(
+          updatedValue: Param(true),
           value: Param(true),
           error: Param('error'),
-          isInitial: false,
         );
 
         final expectedStates = [
@@ -56,10 +58,10 @@ void main() {
         name: 'name',
       );
 
-      initialState = SelectFieldBlocState<bool, dynamic>(
+      initialState = createSelectState<bool, dynamic>(
         value: null,
         error: null,
-        isInitial: true,
+        isDirty: false,
         suggestions: null,
         isValidated: true,
         isValidating: false,
@@ -81,10 +83,10 @@ void main() {
         items: [true, false],
       );
 
-      initialState = SelectFieldBlocState<bool, dynamic>(
+      initialState = createSelectState<bool, dynamic>(
         value: true,
         error: 'error',
-        isInitial: true,
+        isDirty: false,
         suggestions: null,
         isValidated: true,
         isValidating: false,
@@ -103,10 +105,10 @@ void main() {
         name: 'name',
       );
 
-      final state1 = SelectFieldBlocState<bool, dynamic>(
+      final state1 = createSelectState<bool, dynamic>(
         value: null,
         error: null,
-        isInitial: true,
+        isDirty: false,
         suggestions: null,
         isValidated: true,
         isValidating: false,
@@ -160,10 +162,10 @@ void main() {
         items: [true],
       );
 
-      final state1 = SelectFieldBlocState<bool, dynamic>(
+      final state1 = createSelectState<bool, dynamic>(
         value: null,
         error: null,
-        isInitial: true,
+        isDirty: false,
         suggestions: null,
         isValidated: true,
         isValidating: false,
@@ -202,10 +204,10 @@ void main() {
         items: [true, false],
       );
 
-      final state1 = SelectFieldBlocState<bool, dynamic>(
+      final state1 = createSelectState<bool, dynamic>(
         value: null,
         error: null,
-        isInitial: true,
+        isDirty: false,
         suggestions: null,
         isValidated: true,
         isValidating: false,

--- a/packages/form_bloc/test/select_field/select_field_state_test.dart
+++ b/packages/form_bloc/test/select_field/select_field_state_test.dart
@@ -1,64 +1,122 @@
-import 'package:form_bloc/form_bloc.dart';
+import 'package:form_bloc/src/blocs/field/field_bloc.dart';
 import 'package:form_bloc/src/utils.dart';
 import 'package:test/test.dart';
 
+import '../utils/when_bloc.dart';
+
 void main() {
   group('SelectFieldBlocState:', () {
-    test('copyWith.', () {
+    group('copyWith', () {
       Future<List<int>> suggestions(String pattern) async => [1];
 
-      final state = SelectFieldBlocState<int?, dynamic>(
-        value: null,
-        error: null,
-        isInitial: false,
-        suggestions: null,
-        isValidated: false,
-        isValidating: false,
-        name: '',
-        items: [],
-      );
-      final stateCopy1 = state.copyWith(
-        value: Param(1),
-        error: Param('error'),
-        isInitial: true,
-        suggestions: Param(suggestions),
-        isValidated: true,
-        items: [1],
-      );
-      final stateCopy2 = stateCopy1.copyWith(
-        value: Param(null),
-        error: Param(null),
-        isInitial: false,
-        suggestions: Param(null),
-        isValidated: false,
-        items: [],
-      );
-      final stateCopy3 = stateCopy2.copyWith();
+      test('copyWith add values', () {
+        final state1 = SelectFieldBlocState<int, String>(
+          isValueChanged: false,
+          initialValue: null,
+          updatedValue: null,
+          value: null,
+          error: null,
+          suggestions: null,
+          isDirty: false,
+          isValidated: false,
+          isValidating: false,
+          name: 'fieldName',
+          items: [],
+        );
 
-      final statesCopies = [
-        // stateCopy1,
-        stateCopy2,
-        stateCopy3,
-      ];
+        expectState(
+          state1.copyWith(
+            isValueChanged: true,
+            initialValue: Param(0),
+            updatedValue: Param(0),
+            value: Param(0),
+            error: Param('error'),
+            suggestions: Param(suggestions),
+            isDirty: true,
+            isValidated: true,
+            isValidating: true,
+            items: [0],
+          ),
+          SelectFieldBlocState<int, String>(
+            isValueChanged: true,
+            initialValue: 0,
+            updatedValue: 0,
+            value: 0,
+            error: 'error',
+            suggestions: suggestions,
+            isDirty: true,
+            isValidated: true,
+            isValidating: true,
+            name: 'fieldName',
+            items: [0],
+          ),
+        );
+      });
 
-      final expectedStates = [
-        // SelectFieldBlocState<int, dynamic>(
-        //   value: 1,
-        //   error: 'error',
-        //   isInitial: true,
-        //   suggestions: suggestions,
-        //   isValidated: true,
-        //   isValidating: false,
-        //   name: null,
-        //   items: [1],
-        // ),
-        state,
-        state,
-      ];
-      expect(
-        statesCopies,
-        expectedStates,
-      );
+      test('copyWith remove values', () {
+        final state1 = SelectFieldBlocState<int, String>(
+          isValueChanged: true,
+          initialValue: 0,
+          updatedValue: 0,
+          value: 0,
+          error: 'error',
+          suggestions: suggestions,
+          isDirty: true,
+          isValidated: true,
+          isValidating: true,
+          name: 'fieldName',
+          items: [0],
+        );
+
+        expectState(
+          state1.copyWith(
+            isValueChanged: false,
+            initialValue: Param(null),
+            updatedValue: Param(null),
+            value: Param(null),
+            error: Param(null),
+            suggestions: Param(null),
+            isDirty: false,
+            isValidated: false,
+            isValidating: false,
+            items: [],
+          ),
+          SelectFieldBlocState<int, String>(
+            isValueChanged: false,
+            initialValue: null,
+            updatedValue: null,
+            value: null,
+            error: null,
+            suggestions: null,
+            isDirty: false,
+            isValidated: false,
+            isValidating: false,
+            name: 'fieldName',
+            items: [],
+          ),
+        );
+      });
+
+      test('copyWith none', () {
+        final state1 = SelectFieldBlocState<int, String>(
+          isValueChanged: true,
+          initialValue: 0,
+          updatedValue: 0,
+          value: 0,
+          error: 'error',
+          suggestions: suggestions,
+          isDirty: true,
+          isValidated: true,
+          isValidating: true,
+          name: 'fieldName',
+          items: [1],
+        );
+
+        expectState(
+          state1.copyWith(),
+          state1,
+        );
+      });
     });
   });
 }

--- a/packages/form_bloc/test/text_field/text_field_bloc_test.dart
+++ b/packages/form_bloc/test/text_field/text_field_bloc_test.dart
@@ -2,6 +2,8 @@ import 'package:form_bloc/form_bloc.dart';
 import 'package:form_bloc/src/utils.dart';
 import 'package:test/test.dart';
 
+import '../utils/states.dart';
+
 void main() {
   group('TextFieldBloc:', () {
     group('constructor:', () {
@@ -20,18 +22,21 @@ void main() {
         );
 
         final state1 = TextFieldBlocState<dynamic>(
+          isValueChanged: false,
+          initialValue: '',
+          updatedValue: '',
           value: '',
           error: FieldBlocValidatorsErrors.required,
-          isInitial: true,
+          isDirty: false,
           suggestions: suggestions,
           isValidated: true,
           isValidating: false,
           name: 'name',
         );
         final state2 = state1.copyWith(
+          updatedValue: Param('1'),
           value: Param('1'),
           error: Param('error'),
-          isInitial: false,
         );
 
         final expectedStates = [
@@ -55,10 +60,10 @@ void main() {
         name: 'name',
       );
 
-      initialState = TextFieldBlocState<dynamic>(
+      initialState = createTextState<dynamic>(
         value: '',
         error: null,
-        isInitial: true,
+        isDirty: false,
         suggestions: null,
         isValidated: true,
         isValidating: false,
@@ -78,64 +83,10 @@ void main() {
         validators: [(value) => 'error'],
       );
 
-      initialState = TextFieldBlocState<dynamic>(
+      initialState = createTextState<dynamic>(
         value: 'a',
         error: 'error',
-        isInitial: true,
-        suggestions: null,
-        isValidated: true,
-        isValidating: false,
-        name: 'name',
-      );
-
-      expect(
-        fieldBloc.state,
-        initialState,
-      );
-    });
-
-    test('clear method.', () {
-      final fieldBloc = TextFieldBloc<dynamic>(
-        name: 'name',
-        initialValue: '1',
-      );
-
-      final state1 = TextFieldBlocState<dynamic>(
-        value: '1',
-        error: null,
-        isInitial: true,
-        suggestions: null,
-        isValidated: true,
-        isValidating: false,
-        name: 'name',
-      );
-      final state2 = state1.copyWith(
-        value: Param(''),
-        isInitial: true,
-      );
-
-      final expectedStates = [
-        // state1,
-        state2,
-      ];
-      expect(
-        fieldBloc.stream,
-        emitsInOrder(expectedStates),
-      );
-
-      fieldBloc.clear();
-    });
-
-    test('if the initialValue is null, it will be an empty string', () {
-      TextFieldBloc fieldBloc;
-      TextFieldBlocState initialState;
-
-      fieldBloc = TextFieldBloc<dynamic>(name: 'name', initialValue: '');
-
-      initialState = TextFieldBlocState<dynamic>(
-        value: '',
-        error: null,
-        isInitial: true,
+        isDirty: false,
         suggestions: null,
         isValidated: true,
         isValidating: false,

--- a/packages/form_bloc/test/text_field/text_field_state_test.dart
+++ b/packages/form_bloc/test/text_field/text_field_state_test.dart
@@ -1,59 +1,115 @@
-import 'package:form_bloc/form_bloc.dart';
+import 'package:form_bloc/src/blocs/field/field_bloc.dart';
 import 'package:form_bloc/src/utils.dart';
 import 'package:test/test.dart';
 
+import '../utils/when_bloc.dart';
+
 void main() {
   group('TextFieldBlocState:', () {
-    test('copyWith.', () {
+    group('copyWith', () {
       Future<List<String>> suggestions(String pattern) async => ['1'];
 
-      final state = TextFieldBlocState<dynamic>(
-        value: '',
-        error: null,
-        isInitial: false,
-        suggestions: null,
-        isValidated: false,
-        isValidating: false,
-        name: '',
-      );
-      final stateCopy1 = state.copyWith(
-        value: Param('1'),
-        error: Param('error'),
-        isInitial: true,
-        suggestions: Param(suggestions),
-        isValidated: true,
-      );
-      final stateCopy2 = stateCopy1.copyWith(
-        value: Param(''),
-        error: Param(null),
-        isInitial: false,
-        suggestions: Param(null),
-        isValidated: false,
-      );
-      final stateCopy3 = stateCopy2.copyWith();
-      final statesCopies = [
-        // stateCopy1,
-        stateCopy2,
-        stateCopy3,
-      ];
+      test('copyWith add values', () {
+        final state1 = TextFieldBlocState<String>(
+          isValueChanged: false,
+          initialValue: '',
+          updatedValue: '',
+          value: '',
+          error: null,
+          suggestions: null,
+          isDirty: false,
+          isValidated: false,
+          isValidating: false,
+          name: 'fieldName',
+        );
 
-      final expectedStates = [
-        // TextFieldBlocState<dynamic>(
-        //   value: '1',
-        //   error: 'error',
-        //   isInitial: true,
-        //   suggestions: suggestions,
-        //   isValidated: true,
-        //   isValidating: false,
-        //   name: null,
-        // ),
-        state,
-        state,
-      ];
-      expect(
-        statesCopies,
-        expectedStates,
-      );
+        expectState(
+          state1.copyWith(
+            isValueChanged: true,
+            initialValue: Param('value'),
+            updatedValue: Param('value'),
+            value: Param('value'),
+            error: Param('error'),
+            suggestions: Param(suggestions),
+            isDirty: true,
+            isValidated: true,
+            isValidating: true,
+          ),
+          TextFieldBlocState<String>(
+            isValueChanged: true,
+            initialValue: 'value',
+            updatedValue: 'value',
+            value: 'value',
+            error: 'error',
+            suggestions: suggestions,
+            isDirty: true,
+            isValidated: true,
+            isValidating: true,
+            name: 'fieldName',
+          ),
+        );
+      });
+
+      test('copyWith remove values', () {
+        final state1 = TextFieldBlocState<String>(
+          isValueChanged: true,
+          initialValue: 'value',
+          updatedValue: 'value',
+          value: 'value',
+          error: 'error',
+          suggestions: suggestions,
+          isDirty: true,
+          isValidated: true,
+          isValidating: true,
+          name: 'fieldName',
+        );
+
+        expectState(
+          state1.copyWith(
+            isValueChanged: false,
+            initialValue: Param(''),
+            updatedValue: Param(''),
+            value: Param(''),
+            error: Param(null),
+            suggestions: Param(null),
+            isDirty: false,
+            isValidated: false,
+            isValidating: false,
+          ),
+          TextFieldBlocState<String>(
+            isValueChanged: false,
+            initialValue: '',
+            updatedValue: '',
+            value: '',
+            error: null,
+            suggestions: null,
+            isDirty: false,
+            isValidated: false,
+            isValidating: false,
+            name: 'fieldName',
+          ),
+        );
+      });
+
+      test('copyWith none', () {
+        final state1 = TextFieldBlocState<String>(
+          isValueChanged: true,
+          initialValue: 'value',
+          updatedValue: 'value',
+          value: 'value',
+          error: 'error',
+          suggestions: suggestions,
+          isDirty: true,
+          isValidated: true,
+          isValidating: true,
+          name: 'fieldName',
+        );
+
+        expectState(
+          state1.copyWith(),
+          state1,
+        );
+      });
     });
   });
 }

--- a/packages/form_bloc/test/utils/states.dart
+++ b/packages/form_bloc/test/utils/states.dart
@@ -1,5 +1,135 @@
 import 'package:form_bloc/form_bloc.dart';
 
+BooleanFieldBlocState<ExtraData> createBooleanState<ExtraData>({
+  FormBloc? formBloc,
+  String name = 'fieldName',
+  bool value = false,
+  Object? error,
+  bool isDirty = false,
+  Suggestions<bool>? suggestions,
+  bool isValidated = true,
+  bool isValidating = false,
+}) {
+  return BooleanFieldBlocState<ExtraData>(
+    formBloc: formBloc,
+    isValueChanged: false,
+    initialValue: value,
+    updatedValue: value,
+    value: value,
+    error: error,
+    isDirty: isDirty,
+    suggestions: suggestions,
+    isValidated: isValidated,
+    isValidating: isValidating,
+    name: name,
+  );
+}
+
+TextFieldBlocState<ExtraData> createTextState<ExtraData>({
+  FormBloc? formBloc,
+  String name = 'fieldName',
+  String value = '',
+  Object? error,
+  bool isDirty = false,
+  Suggestions<String>? suggestions,
+  bool isValidated = true,
+  bool isValidating = false,
+}) {
+  return TextFieldBlocState<ExtraData>(
+    formBloc: formBloc,
+    isValueChanged: false,
+    initialValue: value,
+    updatedValue: value,
+    value: value,
+    error: error,
+    suggestions: suggestions,
+    isDirty: isDirty,
+    isValidated: isValidated,
+    isValidating: isValidating,
+    name: name,
+  );
+}
+
+SelectFieldBlocState<Value, ExtraData> createSelectState<Value, ExtraData>({
+  FormBloc? formBloc,
+  String name = 'fieldName',
+  Value? value,
+  List<Value>? items,
+  Object? error,
+  bool isDirty = false,
+  Suggestions<Value>? suggestions,
+  bool isValidated = true,
+  bool isValidating = false,
+}) {
+  return SelectFieldBlocState<Value, ExtraData>(
+    formBloc: formBloc,
+    isValueChanged: false,
+    initialValue: value,
+    updatedValue: value,
+    value: value,
+    items: items ?? [],
+    error: error,
+    isDirty: isDirty,
+    suggestions: suggestions,
+    isValidated: isValidated,
+    isValidating: isValidating,
+    name: name,
+  );
+}
+
+MultiSelectFieldBlocState<Value, ExtraData>
+    createMultiSelectState<Value, ExtraData>({
+  FormBloc? formBloc,
+  String name = 'fieldName',
+  List<Value>? value,
+  List<Value>? items,
+  Object? error,
+  bool isDirty = false,
+  Suggestions<Value>? suggestions,
+  bool isValidated = true,
+  bool isValidating = false,
+}) {
+  return MultiSelectFieldBlocState<Value, ExtraData>(
+    formBloc: formBloc,
+    isValueChanged: false,
+    initialValue: value ?? [],
+    updatedValue: value ?? [],
+    value: value ?? [],
+    items: items ?? [],
+    error: error,
+    isDirty: isDirty,
+    suggestions: suggestions,
+    isValidated: isValidated,
+    isValidating: isValidating,
+    name: name,
+  );
+}
+
+InputFieldBlocState<Value, ExtraData> createInputState<Value, ExtraData>({
+  FormBloc? formBloc,
+  String name = 'fieldName',
+  required Value value,
+  Object? error,
+  bool isDirty = false,
+  Suggestions<Value>? suggestions,
+  bool isValidated = true,
+  bool isValidating = false,
+}) {
+  return InputFieldBlocState<Value, ExtraData>(
+    formBloc: formBloc,
+    isValueChanged: false,
+    initialValue: value,
+    updatedValue: value,
+    value: value,
+    error: error,
+    suggestions: suggestions,
+    isDirty: isDirty,
+    isValidated: isValidated,
+    isValidating: isValidating,
+    name: name,
+  );
+}
+
 ListFieldBlocState<T, ExtraData>
     createListState<T extends FieldBloc, ExtraData>({
   FormBloc? formBloc,

--- a/packages/form_bloc/test/utils/when_bloc.dart
+++ b/packages/form_bloc/test/utils/when_bloc.dart
@@ -1,10 +1,16 @@
+import 'dart:async';
+import 'dart:math';
+
 import 'package:bloc/bloc.dart';
+import 'package:fire_line_diff/fire_line_diff.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:rxdart/rxdart.dart';
+import 'package:test/expect.dart';
 
 void whenBloc<State>(
   BlocBase<State> bloc, {
-  Stream<State>? stream,
   State? initialState,
+  Stream<State>? stream,
 }) {
   if (initialState != null) {
     when(() => bloc.state).thenReturn(initialState);
@@ -17,4 +23,81 @@ void whenBloc<State>(
       return state;
     });
   });
+}
+
+void expectState<TState>(TState actual, TState expected) {
+  try {
+    expect(actual, expected);
+  } catch (_) {
+    print(_diffList([actual], [expected]));
+    rethrow;
+  }
+}
+
+Future expectBloc<State>(
+  BlocBase<State> bloc, {
+  State? initalState,
+  FutureOr<void> Function()? act,
+  List<State>? stream,
+}) async {
+  if (initalState != null) {
+    expect(bloc.state, initalState);
+  }
+  if (stream != null) {
+    final states = <State>[];
+    final expectDone =
+        expectLater(bloc.stream.doOnData(states.add), emitsInOrder(stream));
+    final actDone = act?.call();
+    // ignore: void_checks
+    return await Future.wait<void>([
+      expectDone,
+      Future.value(actDone),
+    ]).timeout(Duration(seconds: 5), onTimeout: () {
+      throw 'Timeout expect bloc';
+    }).catchError((Object error) {
+      print(_diffList(stream, states));
+      throw error;
+    });
+  }
+}
+
+String _identical(String str) => '\u001b[90m$str\u001B[0m';
+String _deletion(String str) => '\u001b[31m[-$str-]\u001B[0m';
+String _insertion(String str) => '\u001b[32m{+$str+}\u001B[0m';
+
+String _decorateDiffResult(ItemResult result) {
+  final str =
+      '${'${result.left ?? ''}'.padRight(50, ' ')}${result.right ?? ''}';
+  switch (result.state) {
+    case LineDiffState.positive:
+      return _insertion(str);
+    case LineDiffState.neutral:
+      return _identical(str);
+    case LineDiffState.negative:
+      return _deletion(str);
+  }
+}
+
+String _diff(Object? expected, Object? actual) {
+  return FireLineDiff.diff('$expected'.split('\n'), '$actual'.split('\n'))
+      .map(_decorateDiffResult)
+      .join('\n');
+}
+
+String _diffList<T>(List<T> expected, List<T> actual) {
+  return [
+    '${'Expected:'.padRight(50, ' ')}Actual:',
+    for (var i = 0; i < max(expected.length, actual.length); i++)
+      '$i. ${_diff(expected.getOrNull(i) ?? '', actual.getOrNull(i) ?? '')}',
+  ].join('\n');
+}
+
+extension<T> on List<T> {
+  T? getOrNull(int index) {
+    try {
+      return this[index];
+    } catch (_) {
+      return null;
+    }
+  }
 }


### PR DESCRIPTION
- You can use FieldBloc.updateValue on Bloc space
- You can use FieldBloc.changeValue on widget space
- You can detect is FormBloc/FieldBloc values is changed with hasInitialValue
- You can detect FormBloc/FieldBloc has initial values with hasInitialValues
- You can detect FormBloc/FieldBloc has updated values with hasUpdatedValues
- Fixed an issue where the error was not shown if the field blocs had initial values and there was auto validation active when the user did submit