### PR TITLE
Align horizontal stepper layout with content

### DIFF
--- a/packages/flutter_form_bloc/lib/src/stepper/stepper.dart
+++ b/packages/flutter_form_bloc/lib/src/stepper/stepper.dart
@@ -719,7 +719,9 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
       children: <Widget>[
         SizedBox(
           height: widget.titleHeight,
+          width: double.infinity,
           child: ListView.builder(
+            padding: const EdgeInsets.only(left: 24.0),
             shrinkWrap: true,
             scrollDirection: Axis.horizontal,
             itemCount: children.length,


### PR DESCRIPTION
The beginning of the stepper was misaligned with the content

Before: 
![image](https://user-images.githubusercontent.com/24531420/205767705-c1330714-38f4-4301-9f37-b107f730e0b4.png)

After:
![output](https://user-images.githubusercontent.com/24531420/205768197-ade93f5e-afd7-46fa-bd3c-28c7cd9b8deb.gif)


