### PR TITLE
Add a new debounceDuration property

### DIFF
--- a/packages/flutter_form_bloc/example/android/app/src/main/AndroidManifest.xml
+++ b/packages/flutter_form_bloc/example/android/app/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
          additional functionality it is fine to subclass or reimplement
          FlutterApplication and put your custom class here. -->
     <application
-        android:name="io.flutter.app.FlutterApplication"
+        android:name="${applicationName}"
         android:label="form_bloc_example"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/packages/flutter_form_bloc/lib/src/flutter_typeahead.dart
+++ b/packages/flutter_form_bloc/lib/src/flutter_typeahead.dart
@@ -629,7 +629,7 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
     //   this._suggestionsBox._overlayEntry?.remove();
     // }
     this._suggestionsBox!.widgetMounted = false;
-    WidgetsBinding.instance!.removeObserver(this);
+    WidgetsBinding.instance.removeObserver(this);
 
     if (isWebMobile) {
       _keyboardSubscription.cancel();
@@ -653,7 +653,7 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
   @override
   void initState() {
     super.initState();
-    WidgetsBinding.instance!.addObserver(this);
+    WidgetsBinding.instance.addObserver(this);
     _hideSuggestionsController = PublishSubject<void>();
 
     if (widget.textFieldConfiguration.controller == null) {
@@ -689,7 +689,7 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
       }
     };
 
-    WidgetsBinding.instance!.addPostFrameCallback((duration) {
+    WidgetsBinding.instance.addPostFrameCallback((duration) {
       if (mounted) {
         this._initOverlayEntry();
         // calculate initial suggestions list size
@@ -703,24 +703,21 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
         }
 
         ScrollableState? scrollableState = Scrollable.of(context);
-        if (scrollableState != null) {
-          // The TypeAheadField is inside a scrollable widget
-          scrollableState.position.isScrollingNotifier.addListener(() {
-            bool isScrolling =
-                scrollableState.position.isScrollingNotifier.value;
-            _resizeOnScrollTimer?.cancel();
-            if (isScrolling) {
-              // Scroll started
-              _resizeOnScrollTimer =
-                  Timer.periodic(_resizeOnScrollRefreshRate, (timer) {
-                _suggestionsBox!.resize();
-              });
-            } else {
-              // Scroll finished
+        scrollableState.position.isScrollingNotifier.addListener(() {
+          bool isScrolling =
+              scrollableState.position.isScrollingNotifier.value;
+          _resizeOnScrollTimer?.cancel();
+          if (isScrolling) {
+            // Scroll started
+            _resizeOnScrollTimer =
+                Timer.periodic(_resizeOnScrollRefreshRate, (timer) {
               _suggestionsBox!.resize();
-            }
-          });
-        }
+            });
+          } else {
+            // Scroll finished
+            _suggestionsBox!.resize();
+          }
+        });
       }
     });
   }
@@ -728,7 +725,7 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
   /// TODO: Create Pull Request
   /// Called for resize the suggestions box when have error
   void _onChange() {
-    WidgetsBinding.instance!.addPostFrameCallback((duration) {
+    WidgetsBinding.instance.addPostFrameCallback((duration) {
       _suggestionsBox!.resize();
     });
   }
@@ -982,7 +979,7 @@ class _SuggestionsListState<T> extends State<_SuggestionsList<T>>
     widget.controller!.addListener(this._controllerListener);
 
     _hideSuggestionsSubscription = widget.hideSuggestions.listen((_) {
-      WidgetsBinding.instance!.addPostFrameCallback((duration) {
+      WidgetsBinding.instance.addPostFrameCallback((duration) {
         if (this.mounted) {
           setState(() {
             this
@@ -1205,7 +1202,7 @@ class _SuggestionsListState<T> extends State<_SuggestionsList<T>>
             padding: const EdgeInsets.all(8.0),
             child: Text(
               'Error: ${this._error}',
-              style: TextStyle(color: Theme.of(context).errorColor),
+              style: TextStyle(color: Theme.of(context).colorScheme.error),
             ),
           );
   }
@@ -1687,7 +1684,7 @@ class _SuggestionsBox {
   void open() {
     if (this._isOpened) return;
     assert(this._overlayEntry != null);
-    Overlay.of(context)!.insert(this._overlayEntry!);
+    Overlay.of(context).insert(this._overlayEntry!);
     this._isOpened = true;
   }
 

--- a/packages/flutter_form_bloc/lib/src/stepper/stepper.dart
+++ b/packages/flutter_form_bloc/lib/src/stepper/stepper.dart
@@ -488,8 +488,7 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
               child: TextButton(
                 onPressed: widget.onStepCancel,
                 style: TextButton.styleFrom(
-                  primary: cancelColor,
-                  padding: buttonPadding,
+                  foregroundColor: cancelColor, padding: buttonPadding,
                   shape: buttonShape,
                 ),
                 child: Text(localizations.cancelButtonLabel),
@@ -509,12 +508,12 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
       case StepState.indexed:
       case StepState.editing:
       case StepState.complete:
-        return textTheme.bodyText1;
+        return textTheme.bodyLarge;
       case StepState.disabled:
-        return textTheme.bodyText1!
+        return textTheme.bodyLarge!
             .copyWith(color: _isDark() ? _kDisabledDark : _kDisabledLight);
       case StepState.error:
-        return textTheme.bodyText1!
+        return textTheme.bodyLarge!
             .copyWith(color: _isDark() ? _kErrorDark : _kErrorLight);
     }
   }
@@ -526,12 +525,12 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
       case StepState.indexed:
       case StepState.editing:
       case StepState.complete:
-        return textTheme.caption;
+        return textTheme.bodySmall;
       case StepState.disabled:
-        return textTheme.caption!
+        return textTheme.bodySmall!
             .copyWith(color: _isDark() ? _kDisabledDark : _kDisabledLight);
       case StepState.error:
-        return textTheme.caption!
+        return textTheme.bodySmall!
             .copyWith(color: _isDark() ? _kErrorDark : _kErrorLight);
     }
   }

--- a/packages/flutter_form_bloc/lib/src/text_field_bloc_builder.dart
+++ b/packages/flutter_form_bloc/lib/src/text_field_bloc_builder.dart
@@ -1,17 +1,10 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_form_bloc/flutter_form_bloc.dart';
-import 'package:flutter_form_bloc/src/features/appear/can_show_field_bloc_builder.dart';
 import 'package:flutter_form_bloc/src/flutter_typeahead.dart';
-import 'package:flutter_form_bloc/src/suffix_buttons/clear_suffix_button.dart';
-import 'package:flutter_form_bloc/src/suffix_buttons/obscure_suffix_button.dart';
 import 'package:flutter_form_bloc/src/theme/field_theme_resolver.dart';
-import 'package:flutter_form_bloc/src/theme/form_bloc_theme.dart';
-import 'package:flutter_form_bloc/src/theme/suffix_button_themes.dart';
 import 'package:flutter_form_bloc/src/utils/utils.dart';
-import 'package:form_bloc/form_bloc.dart';
 
 export 'package:flutter/services.dart'
     show TextInputType, TextInputAction, TextCapitalization;
@@ -725,7 +718,7 @@ class TextFieldBlocBuilder extends StatefulWidget {
             fieldTheme.obscureFalseIcon,
       ),
       suggestionsTextStyle: fieldTheme.suggestionsTextStyle ??
-          theme.textTheme.subtitle1!.copyWith(
+          theme.textTheme.titleMedium!.copyWith(
             color: ThemeData.estimateBrightnessForColor(theme.canvasColor) ==
                     Brightness.dark
                 ? Colors.white

--- a/packages/flutter_form_bloc/lib/src/theme/field_theme_resolver.dart
+++ b/packages/flutter_form_bloc/lib/src/theme/field_theme_resolver.dart
@@ -21,14 +21,14 @@ class FieldThemeResolver {
   TextStyle get textStyle {
     return fieldTheme?.textStyle ??
         formTheme.textStyle ??
-        theme.textTheme.subtitle1!;
+        theme.textTheme.titleMedium!;
   }
 
   MaterialStateProperty<Color?> get textColor {
     return fieldTheme?.textColor ??
         formTheme.textColor ??
         SimpleMaterialStateProperty(
-          normal: theme.textTheme.subtitle1!.color,
+          normal: theme.textTheme.titleMedium!.color,
           disabled: theme.disabledColor,
         );
   }

--- a/packages/flutter_form_bloc/lib/src/utils/widgets.dart
+++ b/packages/flutter_form_bloc/lib/src/utils/widgets.dart
@@ -23,10 +23,10 @@ class DefaultFieldBlocBuilderTextStyle extends StatelessWidget {
     return DefaultTextStyle(
       style: Style.resolveTextStyle(
         isEnabled: isEnabled,
-        style: style ?? formStyle.textStyle ?? theme.textTheme.subtitle1!,
+        style: style ?? formStyle.textStyle ?? theme.textTheme.titleMedium!,
         color: formStyle.textColor ??
             SimpleMaterialStateProperty(
-              normal: theme.textTheme.subtitle1!.color,
+              normal: theme.textTheme.titleMedium!.color,
               disabled: theme.disabledColor,
             ),
       ),

--- a/packages/flutter_form_bloc/pubspec.yaml
+++ b/packages/flutter_form_bloc/pubspec.yaml
@@ -6,7 +6,7 @@ repository: https://github.com/GiancarloCode/form_bloc/tree/master/packages/flut
 issue_tracker: https://github.com/GiancarloCode/form_bloc/issues
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ">=2.19.0 <3.0.0"
 
 dependencies:
   flutter:
@@ -20,10 +20,10 @@ dependencies:
   rxdart: ^0.27.3
   flutter_keyboard_visibility: ^5.0.2
   collection: ^1.15.0
-  intl: ^0.17.0
+  intl: ^0.18.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
 
-  flutter_lints: ^1.0.4
+  flutter_lints: ^2.0.1

--- a/packages/flutter_form_bloc/pubspec.yaml
+++ b/packages/flutter_form_bloc/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   rxdart: ^0.27.3
   flutter_keyboard_visibility: ^5.0.2
   collection: ^1.15.0
-  intl: ^0.18.0
+  intl: ^0.17.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/form_bloc/pubspec.yaml
+++ b/packages/form_bloc/pubspec.yaml
@@ -6,7 +6,7 @@ repository: 'https://github.com/GiancarloCode/form_bloc/tree/master/packages/for
 issue_tracker: 'https://github.com/GiancarloCode/form_bloc/issues'
 
 environment:
-  sdk: '>=2.14.0 <3.0.0'
+  sdk: ">=2.19.0 <3.0.0"
 
 dependencies:
   meta: ^1.7.0
@@ -18,8 +18,8 @@ dependencies:
 
 dev_dependencies:
   test: ^1.20.1
-  mocktail: ^0.2.0
+  mocktail: ^0.3.0
   bloc_test: ^9.0.2
   fire_line_diff: ^1.5.3
 
-  lints: ^1.0.1
+  lints: ^2.0.1


### PR DESCRIPTION
**Overview:**
Just after you start typing an email, you get a "email bad formatted" message which could result very annoying for some users.

My proposal is to add a debounce duration that will prevent the field from validating the format until this duration is reached.

I think an average user could write the email with a debounce duration of 500 milliseconds without triggering the field format validation.

By default the duration is 0 because I didn't want to change the behavior for existing projects. 

**Requirements:**
Since my project is based on `Dart 2.19.0`, I also updated the Dart version and ran `dart fix` to comply with the new Dart standards.

**How to test until it's merged:**

Add to your pubspec.yaml
```
dependencies:
  flutter:
    sdk: flutter
  flutter_form_bloc:
    git:
      url: https://github.com/ingmferrer/form_bloc.git
      ref: master
      path: packages/flutter_form_bloc

dependency_overrides:
  form_bloc:
    git:
      url: https://github.com/ingmferrer/form_bloc.git
      ref: master
      path: packages/form_bloc
```

