### PR TITLE
Update flutter_typeahead.dart

### DIFF
--- a/packages/flutter_form_bloc/lib/src/flutter_typeahead.dart
+++ b/packages/flutter_form_bloc/lib/src/flutter_typeahead.dart
@@ -702,7 +702,7 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
           this._suggestionsBox?.open();
         }
 
-        ScrollableState? scrollableState = Scrollable.of(context);
+        ScrollableState? scrollableState = Scrollable.maybeOf(context);
         if (scrollableState != null) {
           // The TypeAheadField is inside a scrollable widget
           scrollableState.position.isScrollingNotifier.addListener(() {


### PR DESCRIPTION
"Scrollable Context Error". It occurs when the Scrollable.of() function is called with a context that does not contain a Scrollable widget.

In this specific case, a TypeAheadField widget is trying to find a Scrollable widget in its widget tree. However, there is no such widget in the tree. The Scrollable widget acts as a container for other widgets, allowing them to scroll when the display space is insufficient.

The error suggests that the TypeAheadField is looking for a Scrollable widget in its widget tree to interact with and adjust to its scrolling behavior. But since it cannot find any Scrollable widget, an exception is thrown.

To avoid this error, it is crucial to ensure that if a widget needs to interact with a Scrollable widget, the latter should be present in the widget tree of the former.