### PR TITLE
Update field_bloc.dart

### DIFF
--- a/packages/form_bloc/lib/src/blocs/field/field_bloc.dart
+++ b/packages/form_bloc/lib/src/blocs/field/field_bloc.dart
@@ -550,6 +550,7 @@ abstract class SingleFieldBloc<
   /// See [FieldBloc.updateFormBloc]
   @override
   void updateFormBloc(FormBloc formBloc, {bool autoValidate = false}) {
+    if (formBloc.isClosed) return;
     _autoValidate = autoValidate;
     if (!_autoValidate) {
       emit(state.copyWith(
@@ -707,6 +708,7 @@ class MultiFieldBloc<ExtraData, TState extends MultiFieldBlocState<ExtraData>>
   /// See [FieldBloc.updateFormBloc]
   @override
   void updateFormBloc(FormBloc formBloc, {bool autoValidate = false}) {
+    if (formBloc.isClosed) return;
     _autoValidate = autoValidate;
 
     emit(state.copyWith(


### PR DESCRIPTION
When modifying emit, _stateController may have been closed and an error will be thrown. All emit methods should check whether the isClosed value has been reached before calling.
``` Dart
void onEmit(State state) {
          if (isClosed) return;
          if (this.state == state && _emitted) return;
          onTransition(
            Transition(
              currentState: this.state,
              event: event as E,
              nextState: state,
            ),
          );
          emit(state);
        }
```
All emit methods in the source code will check the value of isClosed before calling it.