### PR TITLE
[flutter_form_bloc] upgrades intl to 0.19.0 + passes "dart analyze"

### DIFF
--- a/packages/flutter_form_bloc/example/lib/main.dart
+++ b/packages/flutter_form_bloc/example/lib/main.dart
@@ -336,8 +336,8 @@ class LoadingDialog extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return WillPopScope(
-      onWillPop: () async => false,
+    return PopScope(
+      canPop: false,
       child: Center(
         child: Card(
           child: Container(

--- a/packages/flutter_form_bloc/lib/src/checkbox_field_bloc_builder.dart
+++ b/packages/flutter_form_bloc/lib/src/checkbox_field_bloc_builder.dart
@@ -68,21 +68,21 @@ class CheckboxFieldBlocBuilder extends StatelessWidget {
   final TextStyle? textStyle;
 
   /// {@macro flutter_form_bloc.FieldBlocBuilder.textColor}
-  final MaterialStateProperty<Color?>? textColor;
+  final WidgetStateProperty<Color?>? textColor;
 
   // ========== [Checkbox] ==========
 
   /// [Checkbox.mouseCursor]
-  final MaterialStateProperty<MouseCursor?>? mouseCursor;
+  final WidgetStateProperty<MouseCursor?>? mouseCursor;
 
   /// [Checkbox.fillColor]
-  final MaterialStateProperty<Color?>? fillColor;
+  final WidgetStateProperty<Color?>? fillColor;
 
   /// [Checkbox.checkColor]
-  final MaterialStateProperty<Color?>? checkColor;
+  final WidgetStateProperty<Color?>? checkColor;
 
   /// [Checkbox.overlayColor]
-  final MaterialStateProperty<Color?>? overlayColor;
+  final WidgetStateProperty<Color?>? overlayColor;
 
   /// [Checkbox.splashRadius]
   final double? splashRadius;

--- a/packages/flutter_form_bloc/lib/src/date_time/date_time_field_bloc_builder.dart
+++ b/packages/flutter_form_bloc/lib/src/date_time/date_time_field_bloc_builder.dart
@@ -78,7 +78,7 @@ class DateTimeFieldBlocBuilder extends StatelessWidget {
   final TextStyle? textStyle;
 
   /// {@macro flutter_form_bloc.FieldBlocBuilder.textColor}
-  final MaterialStateProperty<Color?>? textColor;
+  final WidgetStateProperty<Color?>? textColor;
 
   final DateTime initialDate;
   final DateTime firstDate;

--- a/packages/flutter_form_bloc/lib/src/date_time/date_time_field_bloc_builder_base.dart
+++ b/packages/flutter_form_bloc/lib/src/date_time/date_time_field_bloc_builder_base.dart
@@ -87,7 +87,7 @@ class DateTimeFieldBlocBuilderBase<T> extends StatefulWidget {
   /// {@macro flutter_form_bloc.FieldBlocBuilder.style}
   final TextStyle? textStyle;
 
-  final MaterialStateProperty<Color?>? textColor;
+  final WidgetStateProperty<Color?>? textColor;
 
   /// Defaults `true`
   final bool? showClearIcon;

--- a/packages/flutter_form_bloc/lib/src/date_time/date_time_field_bloc_builder_base.dart
+++ b/packages/flutter_form_bloc/lib/src/date_time/date_time_field_bloc_builder_base.dart
@@ -107,7 +107,7 @@ class DateTimeFieldBlocBuilderBase<T> extends StatefulWidget {
   final TimeOfDay initialTime;
 
   @override
-  _DateTimeFieldBlocBuilderBaseState createState() =>
+  State<DateTimeFieldBlocBuilderBase<T>> createState() =>
       _DateTimeFieldBlocBuilderBaseState();
 
   DateTimeFieldTheme themeStyleOf(BuildContext context) {

--- a/packages/flutter_form_bloc/lib/src/date_time/date_time_field_bloc_builder_base.dart
+++ b/packages/flutter_form_bloc/lib/src/date_time/date_time_field_bloc_builder_base.dart
@@ -170,7 +170,7 @@ class _DateTimeFieldBlocBuilderBaseState<T>
     } else if (widget.type == DateTimeFieldBlocBuilderBaseType.both) {
       final date = await _showDatePicker(context);
 
-      if (date != null) {
+      if (date != null && context.mounted) {
         final time = await _showTimePicker(context);
         result = _combine(date, time);
       }

--- a/packages/flutter_form_bloc/lib/src/date_time/time_field_bloc_builder.dart
+++ b/packages/flutter_form_bloc/lib/src/date_time/time_field_bloc_builder.dart
@@ -71,7 +71,7 @@ class TimeFieldBlocBuilder extends StatelessWidget {
   /// {@macro flutter_form_bloc.FieldBlocBuilder.style}
   final TextStyle? textStyle;
 
-  final MaterialStateProperty<Color?>? textColor;
+  final WidgetStateProperty<Color?>? textColor;
 
   final SelectableDayPredicate? selectableDayPredicate;
   final DatePickerMode initialDatePickerMode = DatePickerMode.day;

--- a/packages/flutter_form_bloc/lib/src/dropdown_field_bloc_builder.dart
+++ b/packages/flutter_form_bloc/lib/src/dropdown_field_bloc_builder.dart
@@ -91,7 +91,7 @@ class DropdownFieldBlocBuilder<Value> extends StatelessWidget {
   final TextStyle? textStyle;
 
   /// {@macro flutter_form_bloc.FieldBlocBuilder.textColor}
-  final MaterialStateProperty<Color?>? textColor;
+  final WidgetStateProperty<Color?>? textColor;
 
   /// Defaults is [TextOverflow.ellipsis]
   final TextOverflow? textOverflow;

--- a/packages/flutter_form_bloc/lib/src/features/appear/can_show_field_bloc_builder.dart
+++ b/packages/flutter_form_bloc/lib/src/features/appear/can_show_field_bloc_builder.dart
@@ -15,7 +15,7 @@ class CanShowFieldBlocBuilder extends StatefulWidget {
   final Widget Function(BuildContext context, bool canShow) builder;
 
   @override
-  _CanShowFieldBlocBuilderState createState() =>
+  State<CanShowFieldBlocBuilder> createState() =>
       _CanShowFieldBlocBuilderState();
 }
 

--- a/packages/flutter_form_bloc/lib/src/flutter_typeahead.dart
+++ b/packages/flutter_form_bloc/lib/src/flutter_typeahead.dart
@@ -1741,6 +1741,7 @@ class _SuggestionsBox {
         timer += 170;
 
         if (widgetMounted &&
+            context.mounted &&
             (MediaQuery.of(context).viewInsets != initial ||
                 _findRootMediaQuery() != initialRootMediaQuery)) {
           return true;

--- a/packages/flutter_form_bloc/lib/src/flutter_typeahead.dart
+++ b/packages/flutter_form_bloc/lib/src/flutter_typeahead.dart
@@ -590,7 +590,7 @@ class TypeAheadField<T> extends StatefulWidget {
         super(key: key);
 
   @override
-  _TypeAheadFieldState<T> createState() => _TypeAheadFieldState<T>();
+  State<TypeAheadField<T>> createState() => _TypeAheadFieldState<T>();
 }
 
 class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
@@ -601,6 +601,7 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
 
   TextEditingController? get _effectiveController =>
       widget.textFieldConfiguration.controller ?? _textEditingController;
+
   FocusNode? get _effectiveFocusNode =>
       widget.textFieldConfiguration.focusNode ?? _focusNode;
   late VoidCallback _focusNodeListener;
@@ -609,6 +610,7 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
 
   // Timer that resizes the suggestion box on each tick. Only active when the user is scrolling.
   Timer? _resizeOnScrollTimer;
+
   // The rate at which the suggestion box will resize when the user is scrolling
   final Duration _resizeOnScrollRefreshRate = const Duration(milliseconds: 500);
 
@@ -650,6 +652,7 @@ class _TypeAheadFieldState<T> extends State<TypeAheadField<T>>
 
   late final KeyboardVisibilityController keyboardVisibilityController;
   late final bool isWebMobile;
+
   @override
   void initState() {
     super.initState();
@@ -1281,9 +1284,9 @@ class _SuggestionsListState<T> extends State<_SuggestionsList<T>>
 
       initialItemCount: suggestions.length,
 
-      reverse: widget.suggestionsBox!.direction == AxisDirection.down
-          ? false
-          : true, // reverses the list to start at the bottom
+      reverse:
+          widget.suggestionsBox!.direction == AxisDirection.down ? false : true,
+      // reverses the list to start at the bottom
 
       itemBuilder: buildItem,
     );

--- a/packages/flutter_form_bloc/lib/src/groups/fields/checkbox_group_field_bloc_builder.dart
+++ b/packages/flutter_form_bloc/lib/src/groups/fields/checkbox_group_field_bloc_builder.dart
@@ -65,7 +65,7 @@ class CheckboxGroupFieldBlocBuilder<Value> extends StatelessWidget {
   final TextStyle? textStyle;
 
   /// {@macro flutter_form_bloc.FieldBlocBuilder.textColor}
-  final MaterialStateProperty<Color?>? textColor;
+  final WidgetStateProperty<Color?>? textColor;
 
   /// {@macro flutter_form_bloc.FieldBlocBuilder.groupStyle}
   final GroupStyle groupStyle;
@@ -78,16 +78,16 @@ class CheckboxGroupFieldBlocBuilder<Value> extends StatelessWidget {
   // ========== [Checkbox] ==========
 
   /// [Checkbox.mouseCursor]
-  final MaterialStateProperty<MouseCursor?>? mouseCursor;
+  final WidgetStateProperty<MouseCursor?>? mouseCursor;
 
   /// [Checkbox.fillColor]
-  final MaterialStateProperty<Color?>? fillColor;
+  final WidgetStateProperty<Color?>? fillColor;
 
   /// [Checkbox.checkColor]
-  final MaterialStateProperty<Color?>? checkColor;
+  final WidgetStateProperty<Color?>? checkColor;
 
   /// [Checkbox.overlayColor]
-  final MaterialStateProperty<Color?>? overlayColor;
+  final WidgetStateProperty<Color?>? overlayColor;
 
   /// [Checkbox.splashRadius]
   final double? splashRadius;

--- a/packages/flutter_form_bloc/lib/src/groups/fields/radio_button_group_field_bloc.dart
+++ b/packages/flutter_form_bloc/lib/src/groups/fields/radio_button_group_field_bloc.dart
@@ -68,7 +68,7 @@ class RadioButtonGroupFieldBlocBuilder<Value> extends StatelessWidget {
   final TextStyle? textStyle;
 
   /// {@macro flutter_form_bloc.FieldBlocBuilder.textColor}
-  final MaterialStateProperty<Color?>? textColor;
+  final WidgetStateProperty<Color?>? textColor;
 
   /// {@macro flutter_form_bloc.FieldBlocBuilder.groupStyle}
   final GroupStyle groupStyle;
@@ -81,13 +81,13 @@ class RadioButtonGroupFieldBlocBuilder<Value> extends StatelessWidget {
   // ========== [Radio] ==========
 
   /// [Radio.mouseCursor]
-  final MaterialStateProperty<MouseCursor?>? mouseCursor;
+  final WidgetStateProperty<MouseCursor?>? mouseCursor;
 
   /// [Radio.fillColor]
-  final MaterialStateProperty<Color?>? fillColor;
+  final WidgetStateProperty<Color?>? fillColor;
 
   /// [Radio.overlayColor]
-  final MaterialStateProperty<Color?>? overlayColor;
+  final WidgetStateProperty<Color?>? overlayColor;
 
   /// [Radio.splashRadius]
   final double? splashRadius;

--- a/packages/flutter_form_bloc/lib/src/stepper/stepper.dart
+++ b/packages/flutter_form_bloc/lib/src/stepper/stepper.dart
@@ -347,7 +347,7 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
     } else {
       return widget.steps[index].isActive
           ? colorScheme.secondary
-          : colorScheme.background;
+          : colorScheme.surface;
     }
   }
 
@@ -477,8 +477,8 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
                       ? null
                       : colorScheme.primary;
                 }),
-                padding: WidgetStateProperty.all<EdgeInsetsGeometry>(
-                    buttonPadding),
+                padding:
+                    WidgetStateProperty.all<EdgeInsetsGeometry>(buttonPadding),
                 shape: WidgetStateProperty.all<OutlinedBorder>(buttonShape),
               ),
               child: Text(localizations.continueButtonLabel),

--- a/packages/flutter_form_bloc/lib/src/stepper/stepper.dart
+++ b/packages/flutter_form_bloc/lib/src/stepper/stepper.dart
@@ -463,23 +463,23 @@ class _StepperState extends State<Stepper> with TickerProviderStateMixin {
             TextButton(
               onPressed: widget.onStepContinue,
               style: ButtonStyle(
-                foregroundColor: MaterialStateProperty.resolveWith<Color?>(
-                    (Set<MaterialState> states) {
-                  return states.contains(MaterialState.disabled)
+                foregroundColor: WidgetStateProperty.resolveWith<Color?>(
+                    (Set<WidgetState> states) {
+                  return states.contains(WidgetState.disabled)
                       ? null
                       : (_isDark()
                           ? colorScheme.onSurface
                           : colorScheme.onPrimary);
                 }),
-                backgroundColor: MaterialStateProperty.resolveWith<Color?>(
-                    (Set<MaterialState> states) {
-                  return _isDark() || states.contains(MaterialState.disabled)
+                backgroundColor: WidgetStateProperty.resolveWith<Color?>(
+                    (Set<WidgetState> states) {
+                  return _isDark() || states.contains(WidgetState.disabled)
                       ? null
                       : colorScheme.primary;
                 }),
-                padding: MaterialStateProperty.all<EdgeInsetsGeometry>(
+                padding: WidgetStateProperty.all<EdgeInsetsGeometry>(
                     buttonPadding),
-                shape: MaterialStateProperty.all<OutlinedBorder>(buttonShape),
+                shape: WidgetStateProperty.all<OutlinedBorder>(buttonShape),
               ),
               child: Text(localizations.continueButtonLabel),
             ),

--- a/packages/flutter_form_bloc/lib/src/switch_field_bloc_builder.dart
+++ b/packages/flutter_form_bloc/lib/src/switch_field_bloc_builder.dart
@@ -75,7 +75,7 @@ class SwitchFieldBlocBuilder extends StatelessWidget {
   final bool animateWhenCanShow;
 
   final TextStyle? textStyle;
-  final MaterialStateProperty<Color?>? textColor;
+  final WidgetStateProperty<Color?>? textColor;
 
   // ========== [Switch] ==========
 
@@ -86,19 +86,19 @@ class SwitchFieldBlocBuilder extends StatelessWidget {
   final ImageProvider? inactiveThumbImage;
 
   /// [Switch.thumbColor]
-  final MaterialStateProperty<Color?>? thumbColor;
+  final WidgetStateProperty<Color?>? thumbColor;
 
   /// [Switch.trackColor]
-  final MaterialStateProperty<Color?>? trackColor;
+  final WidgetStateProperty<Color?>? trackColor;
 
   /// [Switch.materialTapTargetSize]
   final MaterialTapTargetSize? materialTapTargetSize;
 
   /// [Switch.mouseCursor]
-  final MaterialStateProperty<MouseCursor?>? mouseCursor;
+  final WidgetStateProperty<MouseCursor?>? mouseCursor;
 
   /// [Switch.overlayColor]
-  final MaterialStateProperty<Color?>? overlayColor;
+  final WidgetStateProperty<Color?>? overlayColor;
 
   /// [Switch.splashRadius]
   final double? splashRadius;

--- a/packages/flutter_form_bloc/lib/src/text_field_bloc_builder.dart
+++ b/packages/flutter_form_bloc/lib/src/text_field_bloc_builder.dart
@@ -402,9 +402,9 @@ class TextFieldBlocBuilder extends StatefulWidget {
   /// {@template flutter_form_bloc.FieldBlocBuilder.textColor}
   /// It is the color of the text
   ///
-  /// You can receive this state: [MaterialState.disabled]
+  /// You can receive this state: [WidgetState.disabled]
   /// {@endtemplate}
-  final MaterialStateProperty<Color?>? textColor;
+  final WidgetStateProperty<Color?>? textColor;
 
   /// {@macro flutter.widgets.editableText.strutStyle}
   final StrutStyle? strutStyle;

--- a/packages/flutter_form_bloc/lib/src/text_field_bloc_builder.dart
+++ b/packages/flutter_form_bloc/lib/src/text_field_bloc_builder.dart
@@ -732,7 +732,7 @@ class TextFieldBlocBuilder extends StatefulWidget {
   }
 
   @override
-  _TextFieldBlocBuilderState createState() => _TextFieldBlocBuilderState();
+  State<TextFieldBlocBuilder> createState() => _TextFieldBlocBuilderState();
 }
 
 class _TextFieldBlocBuilderState extends State<TextFieldBlocBuilder> {

--- a/packages/flutter_form_bloc/lib/src/theme/field_theme_resolver.dart
+++ b/packages/flutter_form_bloc/lib/src/theme/field_theme_resolver.dart
@@ -24,10 +24,10 @@ class FieldThemeResolver {
         theme.textTheme.titleMedium!;
   }
 
-  MaterialStateProperty<Color?> get textColor {
+  WidgetStateProperty<Color?> get textColor {
     return fieldTheme?.textColor ??
         formTheme.textColor ??
-        SimpleMaterialStateProperty(
+        SimpleWidgetStateProperty(
           normal: theme.textTheme.titleMedium!.color,
           disabled: theme.disabledColor,
         );
@@ -41,8 +41,8 @@ abstract class FieldTheme extends Equatable {
   final TextStyle? textStyle;
 
   /// Resolves the color of the [textStyle].
-  /// You will receive [MaterialState.disabled]
-  final MaterialStateProperty<Color?>? textColor;
+  /// You will receive [WidgetState.disabled]
+  final WidgetStateProperty<Color?>? textColor;
 
   /// The theme for InputDecoration of this field
   final InputDecorationTheme? decorationTheme;

--- a/packages/flutter_form_bloc/lib/src/theme/field_theme_resolver.dart
+++ b/packages/flutter_form_bloc/lib/src/theme/field_theme_resolver.dart
@@ -15,7 +15,7 @@ class FieldThemeResolver {
   InputDecorationTheme get decorationTheme {
     return fieldTheme?.decorationTheme ??
         formTheme.decorationTheme ??
-        theme.inputDecorationTheme;
+        InputDecorationTheme(data: theme.inputDecorationTheme);
   }
 
   TextStyle get textStyle {

--- a/packages/flutter_form_bloc/lib/src/theme/form_bloc_theme.dart
+++ b/packages/flutter_form_bloc/lib/src/theme/form_bloc_theme.dart
@@ -13,7 +13,7 @@ class FormTheme extends Equatable {
   final TextStyle? textStyle;
 
   /// If [FieldTheme.textColor] is null this value is used
-  final MaterialStateProperty<Color?>? textColor;
+  final WidgetStateProperty<Color?>? textColor;
 
   /// If [FieldTheme.decorationTheme] is null this value is used
   final InputDecorationTheme? decorationTheme;
@@ -83,7 +83,7 @@ class FormTheme extends Equatable {
 
   FormTheme copyWith({
     TextStyle? textStyle,
-    MaterialStateProperty<Color?>? textColor,
+    WidgetStateProperty<Color?>? textColor,
     InputDecorationTheme? decorationTheme,
     EdgeInsetsGeometry? padding,
     CheckboxFieldTheme? checkboxTheme,
@@ -154,7 +154,7 @@ class CheckboxFieldTheme extends FieldTheme {
 
   const CheckboxFieldTheme({
     TextStyle? textStyle,
-    MaterialStateProperty<Color?>? textColor,
+    WidgetStateProperty<Color?>? textColor,
     InputDecorationTheme? decorationTheme,
     this.checkboxTheme,
     this.controlAffinity,
@@ -167,7 +167,7 @@ class CheckboxFieldTheme extends FieldTheme {
 
   CheckboxFieldTheme copyWith({
     TextStyle? textStyle,
-    MaterialStateProperty<Color?>? textColor,
+    WidgetStateProperty<Color?>? textColor,
     InputDecorationTheme? decorationTheme,
     CheckboxThemeData? checkboxTheme,
     FieldBlocBuilderControlAffinity? controlAffinity,
@@ -308,7 +308,7 @@ class DateTimeFieldTheme extends FieldTheme {
 
   const DateTimeFieldTheme({
     TextStyle? textStyle,
-    MaterialStateProperty<Color?>? textColor,
+    WidgetStateProperty<Color?>? textColor,
     InputDecorationTheme? decorationTheme,
     this.textAlign,
     this.showClearIcon,
@@ -322,7 +322,7 @@ class DateTimeFieldTheme extends FieldTheme {
 
   DateTimeFieldTheme copyWith({
     TextStyle? textStyle,
-    MaterialStateProperty<Color?>? textColor,
+    WidgetStateProperty<Color?>? textColor,
     InputDecorationTheme? decorationTheme,
     bool? showClearIcon,
     Widget? clearIcon,
@@ -380,7 +380,7 @@ class DropdownFieldTheme extends FieldTheme {
 
   const DropdownFieldTheme({
     TextStyle? textStyle,
-    MaterialStateProperty<Color?>? textColor,
+    WidgetStateProperty<Color?>? textColor,
     InputDecorationTheme? decorationTheme,
     this.textOverflow,
     this.maxLines,
@@ -395,7 +395,7 @@ class DropdownFieldTheme extends FieldTheme {
 
   DropdownFieldTheme copyWith({
     TextStyle? textStyle,
-    MaterialStateProperty<Color?>? textColor,
+    WidgetStateProperty<Color?>? textColor,
     InputDecorationTheme? decorationTheme,
     TextOverflow? textOverflow,
     int? maxLines,
@@ -462,7 +462,7 @@ class SwitchFieldTheme extends FieldTheme {
 
   const SwitchFieldTheme({
     TextStyle? textStyle,
-    MaterialStateProperty<Color?>? textColor,
+    WidgetStateProperty<Color?>? textColor,
     InputDecorationTheme? decorationTheme,
     this.switchTheme,
     this.controlAffinity,
@@ -474,7 +474,7 @@ class SwitchFieldTheme extends FieldTheme {
 
   SwitchFieldTheme copyWith({
     TextStyle? textStyle,
-    MaterialStateProperty<Color?>? textColor,
+    WidgetStateProperty<Color?>? textColor,
     InputDecorationTheme? decorationTheme,
     SwitchThemeData? switchTheme,
     FieldBlocBuilderControlAffinity? controlAffinity,
@@ -514,7 +514,7 @@ class RadioFieldTheme extends FieldTheme {
 
   const RadioFieldTheme({
     TextStyle? textStyle,
-    MaterialStateProperty<Color?>? textColor,
+    WidgetStateProperty<Color?>? textColor,
     InputDecorationTheme? decorationTheme,
     this.radioTheme,
     this.canTapItemTile = false,
@@ -527,7 +527,7 @@ class RadioFieldTheme extends FieldTheme {
 
   RadioFieldTheme copyWith({
     TextStyle? textStyle,
-    MaterialStateProperty<Color?>? textColor,
+    WidgetStateProperty<Color?>? textColor,
     InputDecorationTheme? decorationTheme,
     RadioThemeData? radioTheme,
     bool? canTapItemTile,
@@ -579,7 +579,7 @@ class TextFieldTheme extends FieldTheme {
 
   const TextFieldTheme({
     TextStyle? textStyle,
-    MaterialStateProperty<Color?>? textColor,
+    WidgetStateProperty<Color?>? textColor,
     InputDecorationTheme? decorationTheme,
     this.textAlign,
     @Deprecated('Use clearSuffixButtonTheme.icon') this.clearIcon,
@@ -596,7 +596,7 @@ class TextFieldTheme extends FieldTheme {
 
   TextFieldTheme copyWith({
     TextStyle? textStyle,
-    MaterialStateProperty<Color?>? textColor,
+    WidgetStateProperty<Color?>? textColor,
     InputDecorationTheme? decorationTheme,
     TextAlign? textAlign,
     Widget? clearIcon,

--- a/packages/flutter_form_bloc/lib/src/theme/material_states.dart
+++ b/packages/flutter_form_bloc/lib/src/theme/material_states.dart
@@ -2,19 +2,19 @@ import 'package:equatable/equatable.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_form_bloc/src/utils/to_string.dart';
 
-class SimpleMaterialStateProperty<T> extends Equatable
-    implements MaterialStateProperty<T> {
+class SimpleWidgetStateProperty<T> extends Equatable
+    implements WidgetStateProperty<T> {
   final T normal;
   final T disabled;
 
-  const SimpleMaterialStateProperty({
+  const SimpleWidgetStateProperty({
     required this.normal,
     required this.disabled,
   });
 
   @override
-  T resolve(Set<MaterialState> states) {
-    if (states.contains(MaterialState.disabled)) return disabled;
+  T resolve(Set<WidgetState> states) {
+    if (states.contains(WidgetState.disabled)) return disabled;
     return normal;
   }
 

--- a/packages/flutter_form_bloc/lib/src/utils/style.dart
+++ b/packages/flutter_form_bloc/lib/src/utils/style.dart
@@ -38,11 +38,11 @@ class Style {
   static TextStyle resolveTextStyle({
     required bool isEnabled,
     required TextStyle style,
-    required MaterialStateProperty<Color?> color,
+    required WidgetStateProperty<Color?> color,
   }) {
     return style.copyWith(
       color: color.resolve({
-        if (!isEnabled) MaterialState.disabled,
+        if (!isEnabled) WidgetState.disabled,
       }),
     );
   }

--- a/packages/flutter_form_bloc/lib/src/utils/widgets.dart
+++ b/packages/flutter_form_bloc/lib/src/utils/widgets.dart
@@ -25,7 +25,7 @@ class DefaultFieldBlocBuilderTextStyle extends StatelessWidget {
         isEnabled: isEnabled,
         style: style ?? formStyle.textStyle ?? theme.textTheme.titleMedium!,
         color: formStyle.textColor ??
-            SimpleMaterialStateProperty(
+            SimpleWidgetStateProperty(
               normal: theme.textTheme.titleMedium!.color,
               disabled: theme.disabledColor,
             ),

--- a/packages/flutter_form_bloc/pubspec.yaml
+++ b/packages/flutter_form_bloc/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   rxdart: ^0.27.3
   flutter_keyboard_visibility: ^5.4.1
   collection: ^1.15.0
-  intl: ^0.18.0
+  intl: ^0.19.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/flutter_form_bloc/pubspec.yaml
+++ b/packages/flutter_form_bloc/pubspec.yaml
@@ -13,12 +13,17 @@ dependencies:
     sdk: flutter
 
   flutter_bloc: ^8.0.1
-  form_bloc: ^0.31.0
   equatable: ^2.0.3
   rxdart: ^0.27.3
   flutter_keyboard_visibility: ^5.4.1
   collection: ^1.15.0
   intl: ^0.19.0
+
+  form_bloc: 
+    git:
+      url: https://github.com/enzo-santos/form_bloc
+      path: packages/form_bloc
+      ref: master
 
 dev_dependencies:
   flutter_test:

--- a/packages/flutter_form_bloc/pubspec.yaml
+++ b/packages/flutter_form_bloc/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
 
   flutter_bloc: ^8.0.1
   equatable: ^2.0.3
-  rxdart: ^0.27.3
+  rxdart: ^0.28.0
   flutter_keyboard_visibility: ^5.4.1
   collection: ^1.15.0
   intl: ^0.19.0

--- a/packages/form_bloc/pubspec.yaml
+++ b/packages/form_bloc/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   rxdart: ^0.27.3
   equatable: ^2.0.3
   collection: ^1.15.0
-  uuid: ^3.0.4
+  uuid: ^4.5.1
 
 dev_dependencies:
   test: ^1.20.1

--- a/packages/form_bloc/pubspec.yaml
+++ b/packages/form_bloc/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   meta: ^1.7.0
   bloc: ^8.0.1
-  rxdart: ^0.27.3
+  rxdart: ^0.28.0
   equatable: ^2.0.3
   collection: ^1.15.0
   uuid: ^4.5.1


### PR DESCRIPTION
This PR only affects flutter_form_bloc. It 
- upgrades intl package to 0.19.0, matching the [Flutter pinned version for it](https://github.com/flutter/flutter/blob/main/packages/flutter_localizations/pubspec.yaml#L14)
- replaces deprecated methods/fields with their active counterparts
  - MaterialStateProperty -> WidgetStateProperty
  - ColorScheme.background -> ColorScheme.surface
  - WillPopScope -> PopScope
- replaces private State concrete types with their respective public API (["Avoid using private types in public APIs"](https://dart.dev/tools/linter-rules/library_private_types_in_public_api))
- checks for context.mounted after asynchronous calls (["Do not use BuildContext across asynchronous gaps"](https://dart.dev/tools/linter-rules/use_build_context_synchronously))